### PR TITLE
[BUGFIX] Fix black checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ style-check:
 	@echo "=========="
 	@echo ""
 	@python -m black --check -t py36 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" . && echo "\n\nSuccess" || (echo "\n\nFailure\n\nRun \"make black\" to apply style formatting to your code"; exit 1)
-	@echo ""
 
 .PHONY: quality-check
 ## run code quality checks with flake8

--- a/butterfree/core/loader/__init__.py
+++ b/butterfree/core/loader/__init__.py
@@ -1,7 +1,7 @@
 """Holds spark data loaders for multiple destinations."""
 
 from butterfree.core.loader.historical_feature_store_loader import (
-    HistoricalFeatureStoreLoader
+    HistoricalFeatureStoreLoader,
 )
 from butterfree.core.loader.online_feature_store_loader import OnlineFeatureStoreLoader
 

--- a/butterfree/core/transform/aggregation/__init__.py
+++ b/butterfree/core/transform/aggregation/__init__.py
@@ -1,7 +1,7 @@
 """The Aggregated Transform Component of a Feature Set."""
 
 from butterfree.core.transform.aggregation.aggregated_transform import (
-    AggregatedTransform
+    AggregatedTransform,
 )
 
 __all__ = ["AggregatedTransform"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,5 @@ default_section = THIRDPARTY
 multi_line_output = 3
 indent = '    '
 skip_glob = pip
+use_parantheses = True
+include_trailing_comma = True

--- a/tests/unit/core/transform/aggregation/test_aggregated_feature.py
+++ b/tests/unit/core/transform/aggregation/test_aggregated_feature.py
@@ -2,7 +2,7 @@ import pytest
 
 from butterfree.core.transform import Feature
 from butterfree.core.transform.aggregation.aggregated_transform import (
-    AggregatedTransform
+    AggregatedTransform,
 )
 
 


### PR DESCRIPTION
## Why? :open_book:
To keep high code quality standards in this repo, we've been using black for code formating. But the drone step for style-check wasn't failing when the code was not compliant to black.

## What? :wrench:
This PR changes the `make style-check` command to throw an error when black fails and configure isort to use black's standards for multiline imports.

## How everything was tested? :straight_ruler:
Drone builds.