### PR TITLE
[MLOP-128] Fixes on Butterfree to run on Databricks

### DIFF
--- a/butterfree/core/configs/environment.py
+++ b/butterfree/core/configs/environment.py
@@ -67,7 +67,14 @@ def get_environment_specification(filename: str = None) -> dict:
     return sanitized_spec
 
 
-specification = get_environment_specification()
+specification = {
+    "ENVIRONMENT": "dev",
+    "CASSANDRA_HOST": "test",
+    "CASSANDRA_KEYSPACE": "test",
+    "CASSANDRA_USERNAME": "test",
+    "CASSANDRA_PASSWORD": "test",
+    "FEATURE_STORE_S3_BUCKET": "test",
+}
 
 
 def get_current_environment() -> str:

--- a/butterfree/core/transform/transformations/__init__.py
+++ b/butterfree/core/transform/transformations/__init__.py
@@ -8,7 +8,6 @@ from butterfree.core.transform.transformations.aggregated_transform import (
     AggregatedTransform,
 )
 from butterfree.core.transform.transformations.custom_transform import CustomTransform
-from butterfree.core.transform.transformations.h3_transform import H3HashTransform
 from butterfree.core.transform.transformations.sql_expression_transform import (
     SQLExpressionTransform,
 )
@@ -19,7 +18,6 @@ from butterfree.core.transform.transformations.transform_component import (
 __all__ = [
     "AggregatedTransform",
     "CustomTransform",
-    "H3HashTransform",
     "SQLExpressionTransform",
     "TransformComponent",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-pyspark==2.4.4
+GitPython==3.0.5
 parameters-validation==1.1.5
+pyspark==2.4.4
+PyYAML==5.3

--- a/tests/unit/core/transform/transformations/test_h3_transform.py
+++ b/tests/unit/core/transform/transformations/test_h3_transform.py
@@ -1,5 +1,5 @@
 from butterfree.core.transform.features import Feature
-from butterfree.core.transform.transformations import H3HashTransform
+from butterfree.core.transform.transformations.h3_transform import H3HashTransform
 
 
 class TestH3Transform:


### PR DESCRIPTION
## Why? :open_book:
Testing Butterfree on Databricks some problems were spotted, and we need to solve them.

## What? :wrench:
- remove `H3HashTransform` from `__init__` on `transformation` module.
    - If h3 plugin not installed it generates an error)
- hard-code `specification` in `environment` module, in Databricks the module does not find a specific YAML configuration. 
    - This is a quick-win fix, we need to investigate a better way to deal with this problem. There is a task do specify secrets using spark confs for example...)
- Updating requirements

## How everything was tested? :straight_ruler:
- Databricks notebook/cluster installation
