### PR TITLE
[MLOP-98] Add gitdb2 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 GitPython==3.0.5
+gitdb2==2.0.6
 parameters-validation==1.1.5
 pyspark==2.4.4
 PyYAML==5.3


### PR DESCRIPTION
## Why? :open_book:
To fix the error: 
```pip/deps/butterfree/core/configs/environment.py:5: in <module>
    import git
pip/deps/git/__init__.py:38: in <module>
    from git.exc import *                       # @NoMove @IgnorePep8
pip/deps/git/exc.py:9: in <module>
    from git.compat import UnicodeMixin, safe_decode, string_types
pip/deps/git/compat.py:16: in <module>
    from gitdb.utils.compat import (
E   ModuleNotFoundError: No module named 'gitdb.utils.compat'
```

## What? :wrench:
- add gitdb2 to requirements

## How everything was tested? :straight_ruler:
- after added to requirements no more error in drone happened
