### PR TITLE
[MLOP-167] Fix Repartition Method

### DIFF
--- a/butterfree/core/load/writers/historical_feature_store_writer.py
+++ b/butterfree/core/load/writers/historical_feature_store_writer.py
@@ -138,6 +138,5 @@ class HistoricalFeatureStoreWriter(Writer):
         dataframe = dataframe.withColumn(
             columns.PARTITION_DAY, dayofmonth(dataframe[columns.TIMESTAMP_COLUMN])
         )
-        dataframe.repartition(*self.PARTITION_BY)
 
-        return dataframe
+        return dataframe.repartition(*self.PARTITION_BY)


### PR DESCRIPTION
## Why? :open_book:
The repartition method was in wrong place and didn't result in DataFrame partitioned.

## What? :wrench:
- HistoricalFeatureStoreWriter