### PR TITLE
Add drone step for automatic releasing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -134,6 +134,18 @@ pipeline:
       event: push
       branch: staging
 
+  release-prod:
+    image: plugins/github-release
+    pull: true
+    files: dist/*
+    title: .version
+    secrets:
+      - source: github_access_token
+        target: github_token
+    when:
+      branch: [ master ]
+      event: [ tag ]
+
   publish-prod:
     image: python:3.6
     commands:


### PR DESCRIPTION
## Why? :open_book:
Drone is automatically creating new tags. This event trigger an automatic deploy of a new version of butterfree python package. But it doesn't create a new **release**, so we can't track the releases in github:

![image](https://user-images.githubusercontent.com/19557581/76364646-5c6eb680-6304-11ea-8094-3d9c58da98da.png)

## What? :wrench:
This PR adds a new step to drone pipeline, creating a new release from a tag. This step should be triggered by a tag event on master. The release will have the butterfree version as title, like here:

![image](https://user-images.githubusercontent.com/19557581/76364834-9dff6180-6304-11ea-9927-6362a92bf59d.png)

## How everything was tested? :straight_ruler:
Just copied from other drone pipelines.