### PR TITLE
Release 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,26 @@
 All notable changes to this project will be documented in this file.
 
 Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each release or unreleased log for a better organization.
+
 ## Unreleased
 
+## [0.6.0](https://github.com/quintoandar/butterfree/releases/tag/0.6.0)
 ### Added
-* [MLOP-185] StackTransform ([#105](https://github.com/quintoandar/butterfree/pull/105))
 * [MLOP-209] with_stack on H3HashTransform ([#114](https://github.com/quintoandar/butterfree/pull/114))
+* [MLOP-141] Create client cassandra on butterfree ([#109](https://github.com/quintoandar/butterfree/pull/109))
+* [MLOP-185] StackTransform ([#105](https://github.com/quintoandar/butterfree/pull/105))
+* [MLOP-176] MostFrequent aggregation ([#104](https://github.com/quintoandar/butterfree/pull/104))
 
 ### Changed
+* [MLOP-202] Refactoring Agg - Create AggregatedFeatureSet and refactor AggregatedTransform ([#108](https://github.com/quintoandar/butterfree/pull/108))
+* [MLOP-137] Make data_type argument mandatory ([#107](https://github.com/quintoandar/butterfree/pull/107))
+* [MLOP-136] Improve DataType with supported spark/cassandra types ([#106](https://github.com/quintoandar/butterfree/pull/106))
+* [MLOP-201] Refactoring Agg - Create FrameBoundaries, Window and SparkFunctionTransform ([#103](https://github.com/quintoandar/butterfree/pull/103))
 * [MLOP-168] HistoricalFeatureStoreWriter Create Partitions Tests and Refactoring ([#102](https://github.com/quintoandar/butterfree/pull/102))
+
+### Fixed
+* Fix Types ([#113](https://github.com/quintoandar/butterfree/pull/113))
+* [MLOP-221] H3 and AggregatedFeatureSet bug fix ([#119](https://github.com/quintoandar/butterfree/pull/119))
 
 ## [0.5.0](https://github.com/quintoandar/butterfree/releases/tag/0.5.0)
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "quintoandar-butterfree"
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
New release

## What? :wrench:
### Added
* [MLOP-209] with_stack on H3HashTransform ([#114](https://github.com/quintoandar/butterfree/pull/114))
* [MLOP-141] Create client cassandra on butterfree ([#109](https://github.com/quintoandar/butterfree/pull/109))
* [MLOP-185] StackTransform ([#105](https://github.com/quintoandar/butterfree/pull/105))
* [MLOP-176] MostFrequent aggregation ([#104](https://github.com/quintoandar/butterfree/pull/104))

### Changed
* [MLOP-202] Refactoring Agg - Create AggregatedFeatureSet and refactor AggregatedTransform ([#108](https://github.com/quintoandar/butterfree/pull/108))
* [MLOP-137] Make data_type argument mandatory ([#107](https://github.com/quintoandar/butterfree/pull/107))
* [MLOP-136] Improve DataType with supported spark/cassandra types ([#106](https://github.com/quintoandar/butterfree/pull/106))
* [MLOP-201] Refactoring Agg - Create FrameBoundaries, Window and SparkFunctionTransform ([#103](https://github.com/quintoandar/butterfree/pull/103))
* [MLOP-168] HistoricalFeatureStoreWriter Create Partitions Tests and Refactoring ([#102](https://github.com/quintoandar/butterfree/pull/102))

### Fixed
* Fix Types ([#113](https://github.com/quintoandar/butterfree/pull/113))
* [MLOP-221] H3 and AggregatedFeatureSet bug fix ([#119](https://github.com/quintoandar/butterfree/pull/119))



[MLOP-209]: https://quintoandar.atlassian.net/browse/MLOP-209
[MLOP-141]: https://quintoandar.atlassian.net/browse/MLOP-141
[MLOP-185]: https://quintoandar.atlassian.net/browse/MLOP-185
[MLOP-176]: https://quintoandar.atlassian.net/browse/MLOP-176
[MLOP-202]: https://quintoandar.atlassian.net/browse/MLOP-202
[MLOP-137]: https://quintoandar.atlassian.net/browse/MLOP-137
[MLOP-136]: https://quintoandar.atlassian.net/browse/MLOP-136
[MLOP-201]: https://quintoandar.atlassian.net/browse/MLOP-201
[MLOP-168]: https://quintoandar.atlassian.net/browse/MLOP-168