### PR TITLE
[MLOP-228] Remove cross join from AggregatedFeatureSet

### DIFF
--- a/butterfree/core/transform/transformations/aggregated_transform.py
+++ b/butterfree/core/transform/transformations/aggregated_transform.py
@@ -259,6 +259,23 @@ class AggregatedTransform(TransformComponent):
 
         return dataframe.select(*columns_select)
 
+    def _create_agg_df(self, dataframe, agg_function, slide_function):
+        """Returns a aggregated dataframe.
+
+        Returns a dataframe with the next date regarding the latest
+        source dataframe date.
+
+        Attributes:
+            dataframe:  dataframe to be aggregated.
+            agg_function: aggregation function.
+            slide_function: function that sums days to the lastest date.
+        """
+        return (
+            dataframe.groupBy(self.group_by)
+            .agg(agg_function(TIMESTAMP_COLUMN).alias(TIMESTAMP_COLUMN))
+            .withColumn(TIMESTAMP_COLUMN, slide_function(TIMESTAMP_COLUMN, 1))
+        )
+
     def transform(self, dataframe: DataFrame) -> DataFrame:
         """Performs a transformation to the feature pipeline.
 
@@ -279,6 +296,10 @@ class AggregatedTransform(TransformComponent):
 
         if self._windows:
             agg_df = itertools.chain.from_iterable(agg_df)
+            dataframe = reduce(self._dataframe_list_join, agg_df)
+            agg_df_latest = self._create_agg_df(
+                dataframe, functions.max, functions.date_add
+            )
+            return self._dataframe_list_join(dataframe, agg_df_latest,)
 
-        dataframe = reduce(self._dataframe_list_join, agg_df)
-        return dataframe
+        return reduce(self._dataframe_list_join, agg_df)

--- a/tests/integration/butterfree/core/transform/conftest.py
+++ b/tests/integration/butterfree/core/transform/conftest.py
@@ -53,41 +53,6 @@ def h3_target_df(spark_context, spark_session):
     data = [
         {
             "h3_id": "8ba8100ea0d5fff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "88a8100ea1fffff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "8ca8100ea0d57ff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "89a8100ea0fffff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "86a8100efffffff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "87a8100eaffffff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "8aa8100ea0d7fff",
-            "timestamp": "2016-04-11 00:00:00",
-            "house_id__count_over_1_day_rolling_windows": None,
-        },
-        {
-            "h3_id": "8ba8100ea0d5fff",
             "timestamp": "2016-04-12 00:00:00",
             "house_id__count_over_1_day_rolling_windows": 2,
         },
@@ -234,14 +199,6 @@ def rolling_windows_output_feature_set_dataframe(spark_context, spark_session):
     data = [
         {
             "id": 1,
-            "origin_ts": "2016-04-11 00:00:00",
-            "feature1__avg_over_1_day_rolling_windows": None,
-            "feature1__avg_over_1_week_rolling_windows": None,
-            "feature1__stddev_pop_over_1_day_rolling_windows": None,
-            "feature1__stddev_pop_over_1_week_rolling_windows": None,
-        },
-        {
-            "id": 1,
             "origin_ts": "2016-04-12 00:00:00",
             "feature1__avg_over_1_day_rolling_windows": 350.0,
             "feature1__avg_over_1_week_rolling_windows": 350.0,
@@ -278,14 +235,6 @@ def rolling_windows_output_feature_set_dataframe_base_date(
     spark_context, spark_session
 ):
     data = [
-        {
-            "id": 1,
-            "origin_ts": "2016-04-11 00:00:00",
-            "feature1__avg_over_1_day_rolling_windows": None,
-            "feature2__avg_over_1_week_rolling_windows": None,
-            "feature1__stddev_pop_over_1_day_rolling_windows": None,
-            "feature2__stddev_pop_over_1_week_rolling_windows": None,
-        },
         {
             "id": 1,
             "origin_ts": "2016-04-12 00:00:00",

--- a/tests/unit/butterfree/core/transform/transformations/conftest.py
+++ b/tests/unit/butterfree/core/transform/transformations/conftest.py
@@ -360,8 +360,18 @@ def target_df_pivot_agg_window(spark_context, spark_session):
             "N_feature__avg_over_2_days_rolling_windows": 250,
             "N_feature__stddev_pop_over_2_days_rolling_windows": 50,
         },
+        {
+            "id": 1,
+            "timestamp": "2016-04-14 00:00:00",
+            "S_feature__avg_over_2_days_rolling_windows": None,
+            "S_feature__stddev_pop_over_2_days_rolling_windows": None,
+            "N_feature__avg_over_2_days_rolling_windows": None,
+            "N_feature__stddev_pop_over_2_days_rolling_windows": None,
+        },
     ]
-    df = spark_session.read.json(spark_context.parallelize(data, 1))
+    df = spark_session.read.json(
+        spark_context.parallelize(data).map(lambda x: json.dumps(x))
+    )
     df = df.withColumn(TIMESTAMP_COLUMN, df.timestamp.cast(DataType.TIMESTAMP.spark))
 
     return df
@@ -439,6 +449,16 @@ def target_df_rolling_agg(spark_context, spark_session):
             "feature1__stddev_pop_over_1_week_rolling_windows": 111.80339887498948,
             "feature1__count_over_1_day_rolling_windows": None,
             "feature1__count_over_1_week_rolling_windows": 4,
+        },
+        {
+            "id": 1,
+            "timestamp": "2016-04-19",
+            "feature1__avg_over_1_day_rolling_windows": None,
+            "feature1__avg_over_1_week_rolling_windows": None,
+            "feature1__stddev_pop_over_1_day_rolling_windows": None,
+            "feature1__stddev_pop_over_1_week_rolling_windows": None,
+            "feature1__count_over_1_day_rolling_windows": None,
+            "feature1__count_over_1_week_rolling_windows": None,
         },
     ]
     df = spark_session.read.json(


### PR DESCRIPTION
## Why? :open_book:
The cross join operation was inefficient, so we found another way of achieving the same results without the cross join.

## What? :wrench:
- [X] _Removed ```_get_unique_keys``` method;_
- [X] _Removed ```_set_cross_join_confs``` method;_
- [X] _Removed ```_cross_join_df``` method;_
- [X] _Removed ```_generate_date_sequence_df```;_
- [X] _Removed ```_create_date_range_dataframe```;_
- [X] _All dataframes in ```df_list``` are joined first (full outer);_
- [X] _After there is the creation of two aggregated dataframes, the first one with one day prior to the minimum date and the other one with one day after the maximum date;_
- [X] _Then, these two aggregated dataframes are joined with the result of the joined ```df_list``` (full outer);_
- [x] _Finally, there is a filter operation if ```end_date``` is passed to the feature set._

## How everything was tested? :straight_ruler:
_Automated tests._

## Attention Points :warning:
_It was important that all tests were able to pass without any modifications, so we could assure that the transformations were reaching the same results. That's what happened._