### PR TITLE
[MLOP-279] Refactor Mode

### DIFF
--- a/tests/unit/butterfree/core/transform/conftest.py
+++ b/tests/unit/butterfree/core/transform/conftest.py
@@ -181,7 +181,7 @@ def make_target_df_distinct(spark_context, spark_session):
     data = [
         {
             "h3": "86a8100efffffff",
-            "timestamp": "2019-12-31 00:00:00",
+            "timestamp": "2020-01-01 00:00:00",
             "feature__sum_over_3_days_rolling_windows": None,
         },
         {


### PR DESCRIPTION
## Why? :open_book:
Instead of returning a single value, mode should return a list of the most 10 frequent values.

## What? :wrench:
Refactor mode to return a list.