### PR TITLE
Release 0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each 
 
 ## Unreleased
 
+## [0.10.2](https://github.com/quintoandar/butterfree/releases/tag/0.10.2)
+### Added
+* [MLOP-316] Test Notebook Examples Makefile Command ([#165](https://github.com/quintoandar/butterfree/pull/165))
+* [MLOP-254] Create notebook with aggregated feature set ([#164](https://github.com/quintoandar/butterfree/pull/164))
+* [MLOP-255] Stream Notebook Example ([#167](https://github.com/quintoandar/butterfree/pull/167))
+* [MLOP-325] Enable stream in FileReader and OnlineFeatureStoreWriter in Debug Mode ([#166](https://github.com/quintoandar/butterfree/pull/166))
+
+### Fixed
+* Fix PyYAML version. ([#169](https://github.com/quintoandar/butterfree/pull/169))
+
 ## [0.10.1](https://github.com/quintoandar/butterfree/releases/tag/0.10.1)
 ### Added
 * [MLOP-253] Create notebook with spark functions transform and windows ([#160](https://github.com/quintoandar/butterfree/pull/160))

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "quintoandar-butterfree"
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
Release 0.10.2

## What? :wrench:
- [MLOP-316] Test Notebook Examples Makefile Command ([#165](https://github.com/quintoandar/butterfree/pull/165))
- [MLOP-254] Create notebook with aggregated feature set ([#164](https://github.com/quintoandar/butterfree/pull/164))
- [MLOP-255] Stream Notebook Example ([#167](https://github.com/quintoandar/butterfree/pull/167))
- [MLOP-325] Enable stream in FileReader and OnlineFeatureStoreWriter in Debug Mode ([#166](https://github.com/quintoandar/butterfree/pull/166))
- Fix PyYAML version. ([#169](https://github.com/quintoandar/butterfree/pull/169))

[MLOP-316]: https://quintoandar.atlassian.net/browse/MLOP-316
[MLOP-254]: https://quintoandar.atlassian.net/browse/MLOP-254
[MLOP-255]: https://quintoandar.atlassian.net/browse/MLOP-255
[MLOP-325]: https://quintoandar.atlassian.net/browse/MLOP-325