### PR TITLE
[MLOP-370] Bug in streaming feature sets

### DIFF
--- a/tests/unit/butterfree/core/load/writers/test_online_feature_store_writer.py
+++ b/tests/unit/butterfree/core/load/writers/test_online_feature_store_writer.py
@@ -167,7 +167,7 @@ class TestOnlineFeatureStoreWriter:
 
         # assert
         assert isinstance(stream_handler, StreamingQuery)
-        spark_client.write_stream.assert_called_with(
+        spark_client.write_stream.assert_any_call(
             dataframe,
             processing_time=cassandra_config.stream_processing_time,
             output_mode=cassandra_config.stream_output_mode,


### PR DESCRIPTION
## Why? :open_book:
Related to https://github.com/quintoandar/butterfree/issues/176

## What? :wrench:
Fix on `OnlineFeatureStoreWriter`, `write_stream` method,

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
With PROD data in a databricks notebook [HERE](https://dbc-931ee6e0-6803.cloud.databricks.com/?o=4531937035440038#notebook/4064950976718097/command/4064950976718165). Testing the writing in the feature-set and entity tables simultaneously.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
