### PR TITLE
[MLOP-384] Make imports more simple

### DIFF
--- a/butterfree/__init__.py
+++ b/butterfree/__init__.py
@@ -18,7 +18,8 @@ from butterfree.core.load.writers import (
     OnlineFeatureStoreWriter,
 )
 from butterfree.core.pipelines.feature_set_pipeline import FeatureSetPipeline
-from butterfree.core.transform import AggregatedFeatureSet, FeatureSet
+from butterfree.core.transform import FeatureSet
+from butterfree.core.transform.aggregated_feature_set import AggregatedFeatureSet
 from butterfree.core.transform.features import Feature, KeyFeature, TimestampFeature
 from butterfree.core.transform.transformations import (
     AggregatedTransform,
@@ -39,3 +40,47 @@ from butterfree.testing.dataframe import (
     assert_dataframe_equality,
     create_df_from_collection,
 )
+
+__all__ = [
+    "AbstractClient",
+    "CassandraClient",
+    "SparkClient",
+    "AbstractWriteConfig",
+    "CassandraConfig",
+    "S3Config",
+    "DataType",
+    "repartition_df",
+    "repartition_sort_df",
+    "Source",
+    "explode_json_column",
+    "filter",
+    "forward_fill",
+    "pivot",
+    "replace",
+    "FileReader",
+    "KafkaReader",
+    "TableReader",
+    "Sink",
+    "HistoricalFeatureStoreWriter",
+    "OnlineFeatureStoreWriter",
+    "FeatureSetPipeline",
+    "AggregatedFeatureSet",
+    "FeatureSet",
+    "Feature",
+    "KeyFeature",
+    "TimestampFeature",
+    "AggregatedTransform",
+    "CustomTransform",
+    "H3HashTransform",
+    "SparkFunctionTransform",
+    "SQLExpressionTransform",
+    "StackTransform",
+    "mode",
+    "most_frequent_set",
+    "Function",
+    "Window",
+    "ValidateDataframe",
+    "assert_column_equality",
+    "assert_dataframe_equality",
+    "create_df_from_collection",
+]

--- a/butterfree/core/transform/__init__.py
+++ b/butterfree/core/transform/__init__.py
@@ -1,7 +1,5 @@
 """The Transform Component of a Feature Set."""
 
-
-from butterfree.core.transform.aggregated_feature_set import AggregatedFeatureSet
 from butterfree.core.transform.feature_set import FeatureSet
 
-__all__ = ["FeatureSet", "AggregatedFeatureSet"]
+__all__ = ["FeatureSet"]

--- a/butterfree/core/transform/transformations/__init__.py
+++ b/butterfree/core/transform/transformations/__init__.py
@@ -16,6 +16,9 @@ from butterfree.core.transform.transformations.sql_expression_transform import (
     SQLExpressionTransform,
 )
 from butterfree.core.transform.transformations.stack_transform import StackTransform
+from butterfree.core.transform.transformations.transform_component import (
+    TransformComponent,
+)
 
 __all__ = [
     "AggregatedTransform",
@@ -24,4 +27,5 @@ __all__ = [
     "SparkFunctionTransform",
     "SQLExpressionTransform",
     "StackTransform",
+    "TransformComponent",
 ]


### PR DESCRIPTION
## Why? :open_book:
Importing with Butterfree is a little bit hard. There are several lines of import to declare simples feature sets.

## What? :wrench:
- Imports


## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
