### PR TITLE
Fix __init__

### DIFF
--- a/butterfree/__init__.py
+++ b/butterfree/__init__.py
@@ -34,7 +34,7 @@ from butterfree.core.transform.transformations.user_defined_functions import (
     most_frequent_set,
 )
 from butterfree.core.transform.utils import Function, Window
-from butterfree.core.validations import ValidateDataframe
+from butterfree.core.validations import BasicValidation
 from butterfree.testing.dataframe import (
     assert_column_equality,
     assert_dataframe_equality,
@@ -79,7 +79,7 @@ __all__ = [
     "most_frequent_set",
     "Function",
     "Window",
-    "ValidateDataframe",
+    "BasicValidation",
     "assert_column_equality",
     "assert_dataframe_equality",
     "create_df_from_collection",


### PR DESCRIPTION
## Why? :open_book:
The build from Staging branch is breaking due to PR merge conflicts.

## What? :wrench:
fix on `__init__` from `butterfree` module

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Passed on local tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
