### PR TITLE
Fixes docs hyperlink on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install git+https://github.com/quintoandar/butterfree.git@staging
 ```
 
 ## Documentation
-The official documentation is hosted on [Read the Docs](https://quintoandar-butterfree.readthedocs-hosted.com/en/latest/home.html)
+The official documentation is hosted on [Read the Docs](https://butterfree.readthedocs.io/en/latest/home.html)
 
 ## License
 TBD


### PR DESCRIPTION
## Why? :open_book:
The current hyperlink on README.md leads to a restricted version. 

## What? :wrench:
This PR replaces the current hyperlink to the public version.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Previous hyperlink requires restricted access

![image](https://user-images.githubusercontent.com/11564309/87828401-38dbef80-c853-11ea-9dbb-f43448cd08ec.png)

The fixed version works as expected

![image](https://user-images.githubusercontent.com/11564309/87828315-09c57e00-c853-11ea-8602-d5df8d63e6da.png)

## Checklist
- [X] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [X] I have performed a self-review of my own code;
- [X] I have made corresponding changes to the documentation;
- [X] I have added tests that prove my fix is effective or that my feature works;
- [X] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
