### PR TITLE
Fixes type hints for `clients` module

### DIFF
--- a/butterfree/clients/abstract_client.py
+++ b/butterfree/clients/abstract_client.py
@@ -1,5 +1,6 @@
 """Abstract class for database clients."""
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class AbstractClient(ABC):
@@ -7,12 +8,12 @@ class AbstractClient(ABC):
 
     @property
     @abstractmethod
-    def conn(self):
+    def conn(self) -> Any:
         """Returns a connection object."""
         pass
 
     @abstractmethod
-    def sql(self, query: str):
+    def sql(self, query: str) -> Any:
         """Runs a query.
 
         Args:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,3 +7,5 @@ twine==3.1.1
 Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 recommonmark==0.6.0
+mypy==0.782
+pyspark-stubs==3.0.0.dev8

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,4 +8,4 @@ Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 recommonmark==0.6.0
 mypy==0.782
-pyspark-stubs==3.0.0.dev8
+pyspark-stubs==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyspark==3.0.0
 PyYAML==5.3
 cassandra-driver==3.22.0
 sphinxemoji==0.1.6
+typing-extensions==3.7.4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,19 @@ include_trailing_comma = True
 spark_options =
     spark.sql.session.timeZone: UTC
     spark.driver.bindAddress: 127.0.0.1
+
+[mypy]
+# suppress errors about unsatisfied imports
+ignore_missing_imports=True
+
+# be strict
+warn_return_any = True
+strict_optional = True
+warn_no_return = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+disallow_any_generics = True
+
+disallow_untyped_defs = True
+check_untyped_defs = True
+disallow_untyped_calls = True

--- a/tests/unit/butterfree/clients/conftest.py
+++ b/tests/unit/butterfree/clients/conftest.py
@@ -1,19 +1,22 @@
+from typing import Any, Dict, List
 from unittest.mock import Mock
 
 import pytest
+from pyspark import SparkContext
+from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.streaming import StreamingQuery
 
 from butterfree.clients import CassandraClient
 
 
 @pytest.fixture()
-def target_df(spark_context, spark_session):
+def target_df(spark_context: SparkContext, spark_session: SparkSession) -> DataFrame:
     data = [{"col1": "value", "col2": 123}]
-    return spark_session.read.json(spark_context.parallelize(data, 1))
+    return spark_session.read.json(spark_context.parallelize(data, 1))  # type: ignore
 
 
 @pytest.fixture()
-def mocked_spark_read():
+def mocked_spark_read() -> Mock:
     mock = Mock()
     mock.readStream = mock
     mock.read = mock
@@ -23,7 +26,7 @@ def mocked_spark_read():
 
 
 @pytest.fixture()
-def mocked_spark_write():
+def mocked_spark_write() -> Mock:
     mock = Mock()
     mock.dataframe = mock
     mock.write = mock
@@ -31,7 +34,7 @@ def mocked_spark_write():
 
 
 @pytest.fixture()
-def mocked_stream_df():
+def mocked_stream_df() -> Mock:
     mock = Mock()
     mock.isStreaming = True
     mock.writeStream = mock
@@ -44,14 +47,14 @@ def mocked_stream_df():
 
 
 @pytest.fixture
-def cassandra_client():
+def cassandra_client() -> CassandraClient:
     return CassandraClient(
         cassandra_host=["mock"], cassandra_key_space="dummy_keyspace"
     )
 
 
 @pytest.fixture
-def cassandra_feature_set():
+def cassandra_feature_set() -> List[Dict[str, Any]]:
     return [
         {"feature1": "value1", "feature2": 10.5},
         {"feature1": "value1", "feature2": 10},

--- a/tests/unit/butterfree/clients/test_cassandra_client.py
+++ b/tests/unit/butterfree/clients/test_cassandra_client.py
@@ -1,17 +1,19 @@
+from typing import Any, Dict, List
 from unittest.mock import MagicMock
 
 import pytest
 
 from butterfree.clients import CassandraClient
+from butterfree.clients.cassandra_client import CassandraColumn
 
 
-def sanitize_string(query):
+def sanitize_string(query: str) -> str:
     """Remove multiple spaces and new lines"""
     return " ".join(query.split())
 
 
 class TestCassandraClient:
-    def test_conn(self, cassandra_client):
+    def test_conn(self, cassandra_client: CassandraClient) -> None:
         # arrange
         cassandra_client = CassandraClient(
             cassandra_host=["mock"], cassandra_key_space="dummy_keyspace"
@@ -23,8 +25,14 @@ class TestCassandraClient:
         # assert
         assert start_conn is None
 
-    def test_cassandra_client_sql(self, cassandra_client, cassandra_feature_set):
-        cassandra_client.sql = MagicMock(return_value=cassandra_feature_set)
+    def test_cassandra_client_sql(
+        self,
+        cassandra_client: CassandraClient,
+        cassandra_feature_set: List[Dict[str, Any]],
+    ) -> None:
+        cassandra_client.sql = MagicMock(  # type: ignore
+            return_value=cassandra_feature_set
+        )
 
         assert isinstance(
             cassandra_client.sql(
@@ -39,8 +47,8 @@ class TestCassandraClient:
             )
         )
 
-    def test_cassandra_get_schema(self, cassandra_client):
-        cassandra_client.sql = MagicMock(
+    def test_cassandra_get_schema(self, cassandra_client: CassandraClient) -> None:
+        cassandra_client.sql = MagicMock(  # type: ignore
             return_value=[
                 {"column_name": "feature1", "type": "text"},
                 {"column_name": "feature2", "type": "bigint"},
@@ -60,10 +68,14 @@ class TestCassandraClient:
 
         assert sanitize_string(query) == sanitize_string(expected_query)
 
-    def test_cassandra_create_table(self, cassandra_client, cassandra_feature_set):
-        cassandra_client.sql = MagicMock()
+    def test_cassandra_create_table(
+        self,
+        cassandra_client: CassandraClient,
+        cassandra_feature_set: List[Dict[str, Any]],
+    ) -> None:
+        cassandra_client.sql = MagicMock()  # type: ignore
 
-        columns = [
+        columns: List[CassandraColumn] = [
             {"column_name": "id", "type": "int", "primary_key": True},
             {"column_name": "rent_per_month", "type": "float", "primary_key": False},
         ]
@@ -79,7 +91,7 @@ class TestCassandraClient:
 
         assert sanitize_string(query) == sanitize_string(expected_query)
 
-    def test_cassandra_without_session(self, cassandra_client):
+    def test_cassandra_without_session(self, cassandra_client: CassandraClient) -> None:
         cassandra_client = cassandra_client
 
         with pytest.raises(


### PR DESCRIPTION
## Why? :open_book:
Fixes type hints for `clients` module

## What? :wrench:

I've introduced `mypy`, `pyspark-stubs` and `typing_extesions` as a dependecies.
All *Type Hint* was fixed in `clients` module (lib and tests).

* `AbstractClient` was transformed in a **GenericType**
* Fixed types in `SparkClient` and `CassandraClient`
* `CassandraColumn` type was created
* `clients` tests were typed too

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:

Mypy check:
```sh
mypy butterfree/clients
```

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:

I didn't include the `mypy` to `donre` check because we have to fixes the other modules, to prevent the falling build for a long time!

refs #195 