### PR TITLE
Adding the library motto to readme and python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ## Butterfree
+_A tool for building feature stores. Transform your raw data into beautiful features._
+
 Made with :heart: by the **MLOps** team from [QuintoAndar](https://github.com/quintoandar/)
 
 This library supports Python version 3.6+ and meant to provide tools for building ETL pipelines for Feature Stores using [Apache Spark](https://spark.apache.org/).

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ setup(
     author="QuintoAndar",
     install_requires=requirements,
     extras_require={"h3": ["cmake==3.16.3", "h3==3.4.2"]},
+    python_requires=">=3.6, <4",
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ with open("README.md") as f:
 
 setup(
     name=__package_name__,
-    description="A tool for building feature stores.",
+    description="A tool for building feature stores - Transform your raw data "
+    "into beautiful features.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     keywords="feature store sets ETL",


### PR DESCRIPTION
## Why? :open_book:
We should start using a consistent motto when referring to the library

## What? :wrench:
Adds our motto to the top of README and to the package description

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
