### PR TITLE
Fix H3 import

### DIFF
--- a/butterfree/transform/transformations/__init__.py
+++ b/butterfree/transform/transformations/__init__.py
@@ -21,7 +21,6 @@ from butterfree.transform.transformations.transform_component import TransformCo
 __all__ = [
     "AggregatedTransform",
     "CustomTransform",
-    "H3HashTransform",
     "SparkFunctionTransform",
     "SQLExpressionTransform",
     "StackTransform",

--- a/butterfree/transform/transformations/__init__.py
+++ b/butterfree/transform/transformations/__init__.py
@@ -8,7 +8,6 @@ from butterfree.transform.transformations.aggregated_transform import (
     AggregatedTransform,
 )
 from butterfree.transform.transformations.custom_transform import CustomTransform
-from butterfree.transform.transformations.h3_transform import H3HashTransform
 from butterfree.transform.transformations.spark_function_transform import (
     SparkFunctionTransform,
 )

--- a/tests/integration/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/integration/butterfree/transform/test_aggregated_feature_set.py
@@ -6,7 +6,8 @@ from butterfree.constants.data_type import DataType
 from butterfree.testing.dataframe import assert_dataframe_equality
 from butterfree.transform.aggregated_feature_set import AggregatedFeatureSet
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
-from butterfree.transform.transformations import AggregatedTransform, H3HashTransform
+from butterfree.transform.transformations import AggregatedTransform
+from butterfree.transform.transformations.h3_transform import H3HashTransform
 from butterfree.transform.utils.function import Function
 
 

--- a/tests/unit/butterfree/transform/transformations/test_h3_transform.py
+++ b/tests/unit/butterfree/transform/transformations/test_h3_transform.py
@@ -5,7 +5,7 @@ import pytest
 from butterfree.constants.data_type import DataType
 from butterfree.testing.dataframe import assert_dataframe_equality
 from butterfree.transform.features import Feature, KeyFeature
-from butterfree.transform.transformations import H3HashTransform
+from butterfree.transform.transformations.h3_transform import H3HashTransform
 
 
 class TestH3Transform:


### PR DESCRIPTION
## Why? :open_book:
Placing the h3_transform in the __init__ of the transform makes the use of Butterfree always need the h3 lib, so we are removing it from the __init__.

## What? :wrench:
- Imports.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.