### PR TITLE
Fixing an attribute reference error

### DIFF
--- a/butterfree/transform/transformations/aggregated_transform.py
+++ b/butterfree/transform/transformations/aggregated_transform.py
@@ -83,11 +83,15 @@ class AggregatedTransform(TransformComponent):
         ]
 
     def _get_output_name(self, function):
-        base_name = (
-            "__".join([self._parent.name, function.__name__])
-            if hasattr(function, "__name__")
-            else self._parent_name
-        )
+        if not hasattr(function, "__name__"):
+            feature_name = self._parent.name
+            raise AttributeError(
+                f"""Anonymous functions are not supported on AggregatedTransform.
+                    Check feature {feature_name} transforms.
+                """
+            )
+
+        base_name = "__".join([self._parent.name, function.__name__])
         return base_name
 
     @property

--- a/tests/unit/butterfree/transform/transformations/test_aggregated_transform.py
+++ b/tests/unit/butterfree/transform/transformations/test_aggregated_transform.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import pytest
 from pyspark.sql import functions
 
@@ -96,3 +98,20 @@ class TestAggregatedTransform:
         # cast to string to compare the columns definitions because direct column
         # comparison was not working
         assert str(target_aggregations) == str(output_aggregations)
+
+    def test_anonymous_function(self):
+        with pytest.raises(
+            AttributeError,
+            match="Anonymous functions are not supported on AggregatedTransform.",
+        ):
+            Feature(
+                name="feature1",
+                description="unit test",
+                transformation=AggregatedTransform(
+                    functions=[
+                        Function(
+                            func=partial(functions.count), data_type=DataType.INTEGER
+                        )
+                    ]
+                ),
+            ).get_output_columns()


### PR DESCRIPTION
 Raising a more meaningful exception when an anonymous function is passed to an AggregatedTransform

## Why? :open_book:
When passing an anonymous function to an AggregatedTransform an obscure exception was being thrown due to a bug.

## What? :wrench:
I chose to still raise an exception because if we start to support anonymous functions on aggregated transform there would be no easy way to disambiguate between them. It's better to enforce that only named functions are supported and maintain a pattern when constructing feature names. If it's desired in the future we can add support to customizing Names via a property on the Function so we don't always infer based on __name__


## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How everything was tested? :straight_ruler:
Added a Unit test for the new exception

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

