### PR TITLE
[MLOP-416] Add Sonar Step to Test Pipeline on Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
         PR_NUMBER: ${{ github.event.number }}
       run: sonar-scanner \
         -Dsonar.projectName=Butterfree \
-        -Dsonar.projectKey=butterfree \
         -Dsonar.projectBaseDir=. \
         -Dsonar.sources=./butterfree \
         -Dsonar.sourceEncoding=UTF-8 \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Print ref
       env:
         GIT_REF: ${{ github.ref }}
-      run: echo &GIT_REF
+      run: echo $GIT_REF
 
     - name: Setup sonarqube
       if: github.ref == 'ref/head/rafaelleinio/sonar-check'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,15 @@ jobs:
 #    - name: Tests
 #      run: PYTHONPATH=./pip/deps make tests
 
-    - name: Setup sonarqube
-      uses: warchant/setup-sonar-scanner@v1
+  Sonar:
+    runs-on: ubuntu-16.04
+    container: newtmitch/sonar-scanner
+
+    steps:
+    - uses: actions/checkout@v2
+
+#    - name: Setup sonarqube
+#      uses: warchant/setup-sonar-scanner@v1
 
     - name: Run sonarqube
       env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,16 +41,16 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #        SONAR_PASSWORD: ${{ secrets.SONAR_PASSWORD }}}
         PR_NUMBER: ${{ github.event.number }}
-      run: sonar-scanner
-          -Dsonar.projectName=Butterfree \
-          -Dsonar.projectKey=butterfree \
-          -Dsonar.projectBaseDir=. \
-          -Dsonar.sources=./butterfree \
-          -Dsonar.sourceEncoding=UTF-8 \
-          -Dsonar.analysis.mode=preview \
-          -Dsonar.github.pullRequest=$PR_NUMBER \
-          -Dsonar.github.repository=quintoandar/butterfree \
-          -Dsonar.github.oauth=$GITHUB_TOKEN \
-          -Dsonar.host.url=https://sonar.quintoandar.com.br \
-          -Dsonar.login=user \
-          -Dsonar.password=$SONAR_PASSWORD
+      run: sonar-scanner \
+        -Dsonar.projectName=Butterfree \
+        -Dsonar.projectKey=butterfree \
+        -Dsonar.projectBaseDir=. \
+        -Dsonar.sources=./butterfree \
+        -Dsonar.sourceEncoding=UTF-8 \
+        -Dsonar.analysis.mode=preview \
+        -Dsonar.github.pullRequest=$PR_NUMBER \
+        -Dsonar.github.repository=quintoandar/butterfree \
+        -Dsonar.github.oauth=$GITHUB_TOKEN \
+        -Dsonar.host.url=https://sonar.quintoandar.com.br \
+        -Dsonar.login=user \
+        -Dsonar.password=$SONAR_PASSWORD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,17 +14,22 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: make ci-install
+#    - name: Install dependencies
+#      run: make ci-install
+#
+#    - name: Style check
+#      run: PYTHONPATH=./pip/deps make style-check
+#
+#    - name: Quality check
+#      run: PYTHONPATH=./pip/deps make quality-check
+#
+#    - name: Tests
+#      run: PYTHONPATH=./pip/deps make tests
 
-    - name: Style check
-      run: PYTHONPATH=./pip/deps make style-check
-
-    - name: Quality check
-      run: PYTHONPATH=./pip/deps make quality-check
-
-    - name: Tests
-      run: PYTHONPATH=./pip/deps make tests
+    - name: Print ref
+      env:
+        GIT_REF: ${{ github.ref }}
+      run: echo &GIT_REF
 
     - name: Setup sonarqube
       if: github.ref == 'ref/head/rafaelleinio/sonar-check'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,17 +26,10 @@ jobs:
 #    - name: Tests
 #      run: PYTHONPATH=./pip/deps make tests
 
-    - name: Print ref
-      env:
-        GIT_REF: ${{ github.ref }}
-      run: echo $GIT_REF
-
     - name: Setup sonarqube
-      if: github.ref == 'ref/head/rafaelleinio/sonar-check'
       uses: warchant/setup-sonar-scanner@v1
 
     - name: Run sonarqube
-      if: github.ref == 'ref/head/rafaelleinio/sonar-check'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #        SONAR_PASSWORD: ${{ secrets.SONAR_PASSWORD }}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,3 +25,27 @@ jobs:
 
     - name: Tests
       run: PYTHONPATH=./pip/deps make tests
+
+    - name: Setup sonarqube
+      if: github.ref == 'ref/head/rafaelleinio/sonar-check'
+      uses: warchant/setup-sonar-scanner@v1
+
+    - name: Run sonarqube
+      if: github.ref == 'ref/head/rafaelleinio/sonar-check'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#        SONAR_PASSWORD: ${{ secrets.SONAR_PASSWORD }}}
+        PR_NUMBER: ${{ github.event.number }}
+      run: sonar-scanner
+          -Dsonar.projectName=Butterfree \
+          -Dsonar.projectKey=butterfree \
+          -Dsonar.projectBaseDir=. \
+          -Dsonar.sources=./butterfree \
+          -Dsonar.sourceEncoding=UTF-8 \
+          -Dsonar.analysis.mode=preview \
+          -Dsonar.github.pullRequest=$PR_NUMBER \
+          -Dsonar.github.repository=quintoandar/butterfree \
+          -Dsonar.github.oauth=$GITHUB_TOKEN \
+          -Dsonar.host.url=https://sonar.quintoandar.com.br \
+          -Dsonar.login=user \
+          -Dsonar.password=$SONAR_PASSWORD

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,15 +41,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 #        SONAR_PASSWORD: ${{ secrets.SONAR_PASSWORD }}}
         PR_NUMBER: ${{ github.event.number }}
-      run: sonar-scanner \
-        -Dsonar.projectName=Butterfree \
-        -Dsonar.projectBaseDir=. \
-        -Dsonar.sources=./butterfree \
-        -Dsonar.sourceEncoding=UTF-8 \
-        -Dsonar.analysis.mode=preview \
-        -Dsonar.github.pullRequest=$PR_NUMBER \
-        -Dsonar.github.repository=quintoandar/butterfree \
-        -Dsonar.github.oauth=$GITHUB_TOKEN \
-        -Dsonar.host.url=https://sonar.quintoandar.com.br \
-        -Dsonar.login=user \
-        -Dsonar.password=$SONAR_PASSWORD
+      run: sonar-scanner -Dsonar.projectName=Butterfree -Dsonar.projectKey=butterfree -Dsonar.projectBaseDir=. -Dsonar.sources=./butterfree -Dsonar.sourceEncoding=UTF-8 -Dsonar.analysis.mode=preview -Dsonar.github.pullRequest=$PR_NUMBER -Dsonar.github.repository=quintoandar/butterfree -Dsonar.github.oauth=$GITHUB_TOKEN -Dsonar.host.url=https://sonar.quintoandar.com.br -Dsonar.login=user -Dsonar.password=$SONAR_PASSWORD


### PR DESCRIPTION
## Why? :open_book:
we are adding back the Sonar scan quality check to our CI pipeline

## What? :wrench:
- Sonar scan steps

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
with the github actions

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
Only PRs to master branch will be verified since it needs credentials to run
