### PR TITLE
[MLOP-398] Pipeline run method will receive an optional start_date argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each 
 ### Fixed
 * Fix cast to ArrayType ([#161](https://github.com/quintoandar/butterfree/pull/161))
 
+## [0.10.1](https://github.com/quintoandar/butterfree/releases/tag/0.10.1)
+### Added
+* [MLOP-253] Create notebook with spark functions transform and windows ([#160](https://github.com/quintoandar/butterfree/pull/160))
+
+### Fixed
+* Fix cast to ArrayType ([#161](https://github.com/quintoandar/butterfree/pull/161))
+
 ## [0.10.0](https://github.com/quintoandar/butterfree/releases/tag/0.10.0)
 ### Added
 * [MLOP-325] Debug Mode on Writers ([#155](https://github.com/quintoandar/butterfree/pull/155))

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -54,7 +54,9 @@ class Source:
         self.readers = readers
         self.query = query
 
-    def construct(self, client: SparkClient) -> DataFrame:
+    def construct(
+        self, client: SparkClient, start_date: str = None, end_date: str = None
+    ) -> DataFrame:
         """Construct an entry point dataframe for a feature set.
 
         This method will assemble multiple readers, by building each one and

--- a/butterfree/pipelines/feature_set_pipeline.py
+++ b/butterfree/pipelines/feature_set_pipeline.py
@@ -174,6 +174,7 @@ class FeatureSetPipeline:
 
     def run(
         self,
+        start_date: str = None,
         end_date: str = None,
         partition_by: List[str] = None,
         order_by: List[str] = None,
@@ -191,7 +192,11 @@ class FeatureSetPipeline:
         soon. Use only if strictly necessary.
 
         """
-        dataframe = self.source.construct(client=self.spark_client)
+        start_date = self.feature_set.define_start_date(start_date)
+
+        dataframe = self.source.construct(
+            client=self.spark_client, start_date=start_date, end_date=end_date
+        )
 
         if partition_by:
             order_by = order_by or partition_by

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -466,6 +466,19 @@ class AggregatedFeatureSet(FeatureSet):
 
         return schema
 
+    @staticmethod
+    def define_start_date(start_date: str = None):
+        """Get feature set schema.
+
+        Args:
+            start_date: start date regarding source dataframe.
+
+        Returns:
+            start date.
+
+        """
+        return start_date
+
     def construct(
         self,
         dataframe: DataFrame,

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -466,8 +466,7 @@ class AggregatedFeatureSet(FeatureSet):
 
         return schema
 
-    @staticmethod
-    def define_start_date(start_date: str = None):
+    def define_start_date(self, start_date: str = None):
         """Get feature set start date.
 
         Args:

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -468,7 +468,7 @@ class AggregatedFeatureSet(FeatureSet):
 
     @staticmethod
     def define_start_date(start_date: str = None):
-        """Get feature set schema.
+        """Get feature set start date.
 
         Args:
             start_date: start date regarding source dataframe.

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -378,6 +378,19 @@ class FeatureSet:
 
         return df.select([column for column in self.columns])
 
+    @staticmethod
+    def define_start_date(start_date: str = None):
+        """Get feature set schema.
+
+        Args:
+            start_date: start date regarding source dataframe.
+
+        Returns:
+            start date.
+
+        """
+        return start_date
+
     def construct(
         self,
         dataframe: DataFrame,

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -380,7 +380,7 @@ class FeatureSet:
 
     @staticmethod
     def define_start_date(start_date: str = None):
-        """Get feature set schema.
+        """Get feature set start date.
 
         Args:
             start_date: start date regarding source dataframe.

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -378,8 +378,7 @@ class FeatureSet:
 
         return df.select([column for column in self.columns])
 
-    @staticmethod
-    def define_start_date(start_date: str = None):
+    def define_start_date(self, start_date: str = None):
         """Get feature set start date.
 
         Args:

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -389,3 +389,42 @@ class TestAggregatedFeatureSet:
 
         # assert
         assert_dataframe_equality(target_df, output_df)
+
+    def test_define_start_date(self):
+        feature_set = AggregatedFeatureSet(
+            name="feature_set",
+            entity="entity",
+            description="description",
+            features=[
+                Feature(
+                    name="feature1",
+                    description="test",
+                    transformation=AggregatedTransform(
+                        functions=[
+                            Function(functions.avg, DataType.DOUBLE),
+                            Function(functions.stddev_pop, DataType.FLOAT),
+                        ],
+                    ),
+                ),
+                Feature(
+                    name="feature2",
+                    description="test",
+                    transformation=AggregatedTransform(
+                        functions=[Function(functions.count, DataType.ARRAY_STRING)]
+                    ),
+                ),
+            ],
+            keys=[
+                KeyFeature(
+                    name="id",
+                    description="The user's Main ID or device ID",
+                    dtype=DataType.BIGINT,
+                )
+            ],
+            timestamp=TimestampFeature(),
+        ).with_windows(definitions=["1 week", "2 days"])
+
+        start_date = feature_set.define_start_date("2020-08-04")
+
+        assert isinstance(start_date, str)
+        assert start_date == "2020-08-04"

--- a/tests/unit/butterfree/transform/test_feature_set.py
+++ b/tests/unit/butterfree/transform/test_feature_set.py
@@ -421,3 +421,40 @@ class TestFeatureSet:
                 keys=[key_id],
                 timestamp=timestamp_c,
             ).construct(dataframe, spark_client)
+
+    def test_define_start_date(self, key_id, timestamp_c, dataframe):
+        feature_set = FeatureSet(
+            name="feature_set",
+            entity="entity",
+            description="description",
+            features=[
+                Feature(
+                    name="feature1",
+                    description="test",
+                    transformation=SparkFunctionTransform(
+                        functions=[
+                            Function(F.avg, DataType.FLOAT),
+                            Function(F.stddev_pop, DataType.DOUBLE),
+                        ]
+                    ).with_window(
+                        partition_by="id",
+                        order_by=TIMESTAMP_COLUMN,
+                        mode="fixed_windows",
+                        window_definition=["2 minutes", "15 minutes"],
+                    ),
+                ),
+            ],
+            keys=[
+                KeyFeature(
+                    name="id",
+                    description="The user's Main ID or device ID",
+                    dtype=DataType.BIGINT,
+                )
+            ],
+            timestamp=TimestampFeature(),
+        )
+
+        start_date = feature_set.define_start_date("2020-08-04")
+
+        assert isinstance(start_date, str)
+        assert start_date == "2020-08-04"


### PR DESCRIPTION
## Why? :open_book:
The feature set pipeline will receive a start_date parameter, so we can implement interval processing in Butterfree.

## What? :wrench:
Added an optional ```start_date``` parameter to the run method within the scope of the ```FeatureSetPipeline``` class.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit and integration tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
I've also added some methods inside FeatureSet and AggregatedFeatureSet classes to retrieve the proper start_date. For a feature set, it's simply the same start date, however for an aggregated feature set, we should take the time window into account (the logic itself will be implemented later).
