### PR TITLE
Fixes type hints for `constants` module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,8 @@ jobs:
     - name: Quality check
       run: PYTHONPATH=./pip/deps make quality-check
 
+    - name: Static Type check
+      run: PYTHONPATH=./pip/deps make type-check
+
     - name: Tests
       run: PYTHONPATH=./pip/deps make tests

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,18 @@ quality-check:
 	@python -m flake8 && echo "Success"
 	@echo ""
 
+.PHONY: type-check
+## run static type checks
+type-check:
+	@echo ""
+	@echo "mypy"
+	@echo "===="
+	@echo ""
+	@python -m mypy butterfree/clients butterfree/constants
+
 .PHONY: checks
 ## run all code checks
-checks: style-check quality-check
+checks: style-check quality-check type-check
 
 .PHONY: apply-style
 ## fix stylistic errors with black

--- a/butterfree/clients/spark_client.py
+++ b/butterfree/clients/spark_client.py
@@ -223,5 +223,5 @@ class SparkClient(AbstractClient):
 
         """
         if not dataframe.isStreaming:
-            return dataframe.createOrReplaceTempView(name)  # type: ignore
+            return dataframe.createOrReplaceTempView(name)
         return dataframe.writeStream.format("memory").queryName(name).start()

--- a/butterfree/constants/columns.py
+++ b/butterfree/constants/columns.py
@@ -1,7 +1,8 @@
 """Holds common column names, constant through all Butterfree."""
 
+from typing_extensions import Final
 
-TIMESTAMP_COLUMN = "timestamp"
-PARTITION_YEAR = "year"
-PARTITION_MONTH = "month"
-PARTITION_DAY = "day"
+TIMESTAMP_COLUMN: Final = "timestamp"
+PARTITION_YEAR: Final = "year"
+PARTITION_MONTH: Final = "month"
+PARTITION_DAY: Final = "day"

--- a/butterfree/constants/data_type.py
+++ b/butterfree/constants/data_type.py
@@ -2,10 +2,9 @@
 
 from enum import Enum
 
+from pyspark.sql.types import ArrayType, BinaryType, BooleanType
+from pyspark.sql.types import DataType as PySparkDataType
 from pyspark.sql.types import (
-    ArrayType,
-    BinaryType,
-    BooleanType,
     DateType,
     DecimalType,
     DoubleType,
@@ -15,8 +14,10 @@ from pyspark.sql.types import (
     StringType,
     TimestampType,
 )
+from typing_extensions import final
 
 
+@final
 class DataType(Enum):
     """Holds constants for data types within Butterfree."""
 
@@ -34,6 +35,6 @@ class DataType(Enum):
     ARRAY_STRING = (ArrayType(StringType()), "frozen<list<text>>")
     ARRAY_FLOAT = (ArrayType(FloatType()), "frozen<list<float>>")
 
-    def __init__(self, spark, cassandra):
+    def __init__(self, spark: PySparkDataType, cassandra: str) -> None:
         self.spark = spark
         self.cassandra = cassandra

--- a/butterfree/constants/spark_constants.py
+++ b/butterfree/constants/spark_constants.py
@@ -1,9 +1,11 @@
 """Holds common spark constants, present through all Butterfree."""
 
+from typing_extensions import Final
+
 # from spark.sql.shuffle.partitions default value
-DEFAULT_NUM_PARTITIONS = 200
+DEFAULT_NUM_PARTITIONS: Final = 200
 
 # ratio between number of partitions per processor recommended (lower bound: 2)
 # refs:
 # https://github.com/vaquarkhan/Apache-Kafka-poc-and-notes/wiki/Apache-Spark-Join-guidelines-and-Performance-tuning
-PARTITION_PROCESSOR_RATIO = 4
+PARTITION_PROCESSOR_RATIO: Final = 4


### PR DESCRIPTION
## Why? :open_book:
Fixes type hints for `constants` module

## What? :wrench:

All *Type Hint* was fixed in `constants` module.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:

Mypy check:
```sh
mypy butterfree/constants
```

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:

I have added type check to the workflow, but just only for the modules where we fixed the type hints!

refs #195 