### PR TITLE
[MLOP-399] Source date boundaries must be changed

### DIFF
--- a/butterfree/constants/windows.py
+++ b/butterfree/constants/windows.py
@@ -1,0 +1,16 @@
+"""Allowed windows units and lengths in seconds."""
+
+ALLOWED_WINDOWS = {
+    "second": 1,
+    "seconds": 1,
+    "minute": 60,
+    "minutes": 60,
+    "hour": 3600,
+    "hours": 3600,
+    "day": 86400,
+    "days": 86400,
+    "week": 604800,
+    "weeks": 604800,
+    "year": 29030400,
+    "years": 29030400,
+}

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -1,6 +1,6 @@
 """AggregatedFeatureSet entity."""
 import itertools
-from datetime import timedelta
+from datetime import datetime, timedelta
 from functools import reduce
 from typing import Dict, List
 
@@ -8,6 +8,7 @@ from pyspark import sql
 from pyspark.sql import DataFrame, functions
 
 from butterfree.clients import SparkClient
+from butterfree.constants.windows import ALLOWED_WINDOWS
 from butterfree.dataframe_service import repartition_df
 from butterfree.transform import FeatureSet
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
@@ -465,6 +466,39 @@ class AggregatedFeatureSet(FeatureSet):
                 schema.append({"column_name": n, "type": dt, "primary_key": False})
 
         return schema
+
+    @staticmethod
+    def _get_biggest_window_in_days(definitions: List[str]):
+        windows_list = []
+        for window in definitions:
+            windows_list.append(
+                int(window.split()[0]) * ALLOWED_WINDOWS[window.split()[1]]
+            )
+        return max(windows_list) / (60 * 60 * 24)
+
+    def define_start_date(self, start_date: str = None):
+        """Get feature set start date.
+
+        Args:
+            start_date: start date regarding source dataframe.
+
+        Returns:
+            start date.
+
+        """
+        if self._windows:
+            window_definition = [
+                definition.frame_boundaries.window_definition
+                for definition in self._windows
+            ]
+            biggest_window = self._get_biggest_window_in_days(window_definition)
+
+            return (
+                datetime.strptime(start_date, "%Y-%m-%d")
+                - timedelta(days=int(biggest_window) + 1)
+            ).strftime("%Y-%m-%d")
+
+        return start_date
 
     def construct(
         self,

--- a/butterfree/transform/utils/window_spec.py
+++ b/butterfree/transform/utils/window_spec.py
@@ -3,6 +3,7 @@ from pyspark import sql
 from pyspark.sql import functions
 
 from butterfree.constants.columns import TIMESTAMP_COLUMN
+from butterfree.constants.windows import ALLOWED_WINDOWS
 
 
 class FrameBoundaries:
@@ -13,21 +14,6 @@ class FrameBoundaries:
         window_definition: time ranges to be used in the windows,
         it can be second(s), minute(s), hour(s), day(s), week(s) and year(s),
     """
-
-    __ALLOWED_WINDOWS = {
-        "second": 1,
-        "seconds": 1,
-        "minute": 60,
-        "minutes": 60,
-        "hour": 3600,
-        "hours": 3600,
-        "day": 86400,
-        "days": 86400,
-        "week": 604800,
-        "weeks": 604800,
-        "year": 29030400,
-        "years": 29030400,
-    }
 
     def __init__(self, mode=None, window_definition=None):
         self.mode = mode
@@ -48,7 +34,7 @@ class FrameBoundaries:
         if self.window_definition is None:
             return None
         u = self.window_definition.split()[1]
-        if u not in self.__ALLOWED_WINDOWS and self.mode != "row_windows":
+        if u not in ALLOWED_WINDOWS and self.mode != "row_windows":
             raise ValueError("Not allowed")
 
         return u
@@ -61,7 +47,7 @@ class FrameBoundaries:
             span = self.window_size - 1
             return w.rowsBetween(-span, 0)
         if self.mode == "fixed_windows":
-            span = self.__ALLOWED_WINDOWS[self.window_unit] * self.window_size
+            span = ALLOWED_WINDOWS[self.window_unit] * self.window_size
             return w.rangeBetween(-span, 0)
 
 

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -389,3 +389,29 @@ class TestAggregatedFeatureSet:
 
         # assert
         assert_dataframe_equality(target_df, output_df)
+
+    def test_feature_set_start_date(
+        self, timestamp_c, feature_set_with_distinct_dataframe,
+    ):
+
+        fs = AggregatedFeatureSet(
+            name="name",
+            entity="entity",
+            description="description",
+            features=[
+                Feature(
+                    name="feature",
+                    description="test",
+                    transformation=AggregatedTransform(
+                        functions=[Function(functions.sum, DataType.INTEGER)]
+                    ),
+                ),
+            ],
+            keys=[KeyFeature(name="h3", description="test", dtype=DataType.STRING)],
+            timestamp=timestamp_c,
+        ).with_windows(["10 days", "3 weeks", "90 days"])
+
+        # assert
+        start_date = fs.define_start_date("2016-04-14")
+
+        assert start_date == "2016-01-14"


### PR DESCRIPTION
## Why? :open_book:
The Source class must be filtered according to the feature set definition.

## What? :wrench:
Added a method in AggregatedFeatureSet to obtain the correct starting data for computing the transformations.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How everything was tested? :straight_ruler:
Unit tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
