### PR TITLE
[MLOP-400] Readers Incremental Strategy

### DIFF
--- a/butterfree/configs/environment.py
+++ b/butterfree/configs/environment.py
@@ -34,8 +34,8 @@ def get_variable(variable_name: str, default_value: str = None) -> str:
     """Gets an environment variable.
 
     The variable comes from it's explicitly declared value in the running
-    environment or from the default value declared in the environment.yaml
-    specification or from the default_value.
+    environment or from the default value declared in specification or from the
+    default_value.
 
     Args:
         variable_name: environment variable name.

--- a/butterfree/extract/readers/__init__.py
+++ b/butterfree/extract/readers/__init__.py
@@ -1,6 +1,7 @@
 """The Reader Component of a Source."""
 from butterfree.extract.readers.file_reader import FileReader
+from butterfree.extract.readers.incremental_strategy import IncrementalStrategy
 from butterfree.extract.readers.kafka_reader import KafkaReader
 from butterfree.extract.readers.table_reader import TableReader
 
-__all__ = ["FileReader", "KafkaReader", "TableReader"]
+__all__ = ["FileReader", "KafkaReader", "TableReader", "IncrementalStrategy"]

--- a/butterfree/extract/readers/incremental_strategy.py
+++ b/butterfree/extract/readers/incremental_strategy.py
@@ -1,0 +1,98 @@
+"""IncrementalStrategy entity."""
+
+from __future__ import annotations
+
+
+class IncrementalStrategy:
+    """Define an incremental strategy to be used on data sources.
+
+    Entity responsible for defining a column expression that will be used to
+    filter the original data source. The purpose is to get only the data related
+    to a specific pipeline execution time interval.
+
+    Attributes:
+        column: column expression on which incremental filter will be applied.
+            The expression need to result on a date or timestamp format, so the
+            filter can properly work with the defined upper and lower bounds.
+
+    """
+
+    def __init__(self, column: str = None):
+        self.column = column
+
+    def from_milliseconds(self, column_name: str) -> IncrementalStrategy:
+        """Create a column expression from ts column defined as milliseconds.
+
+        Args:
+            column_name: column name where the filter will be applied.
+
+        Returns:
+            `IncrementalStrategy` with the defined column expression.
+
+        """
+        return IncrementalStrategy(column=f"date(from_unixtime({column_name}/ 1000.0))")
+
+    def from_string(self, column_name: str, mask: str = None) -> IncrementalStrategy:
+        """Create a column expression from ts column defined as a simple string.
+
+        Args:
+            column_name: column name where the filter will be applied.
+            mask: mask defining the date/timestamp format on the string.
+
+        Returns:
+            `IncrementalStrategy` with the defined column expression.
+
+        """
+        return IncrementalStrategy(column=f"to_date({column_name}, '{mask}')")
+
+    def from_year_month_day_partitions(
+        self,
+        year_column: str = "year",
+        month_column: str = "month",
+        day_column: str = "day",
+    ) -> IncrementalStrategy:
+        """Create a column expression from year, month and day partitions.
+
+        Args:
+            year_column: column name from the year partition.
+            month_column: column name from the month partition.
+            day_column: column name from the day partition.
+
+        Returns:
+            `IncrementalStrategy` with the defined column expression.
+
+        """
+        return IncrementalStrategy(
+            column=f"date(concat(string({year_column}), "
+            f"'-', string({month_column}), "
+            f"'-', string({day_column})))"
+        )
+
+    def get_expression(self, start_date: str = None, end_date: str = None) -> str:
+        """Get the incremental filter expression using the defined dates.
+
+        Both arguments can be set to defined a specific date interval, but  it's
+        only necessary to set one of the arguments for this method to work.
+
+        Args:
+            start_date: date lower bound to use in the filter.
+            end_date: date upper bound to use in the filter.
+
+        Returns:
+            Filter expression based on defined column and bounds.
+
+        Raises:
+            ValuerError: If both arguments, start_date and end_date, are None.
+            ValueError: If the column expression was not defined.
+
+        """
+        if not self.column:
+            raise ValueError("column parameter can't be None")
+        if not (start_date or end_date):
+            raise ValueError("Both arguments start_date and end_date can't be None.")
+        if start_date:
+            expression = f"{self.column} >= date('{start_date}')"
+            if end_date:
+                expression += f" and {self.column} <= date('{end_date}')"
+            return expression
+        return f"{self.column} <= date('{end_date}')"

--- a/tests/unit/butterfree/extract/conftest.py
+++ b/tests/unit/butterfree/extract/conftest.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from pyspark.sql.functions import col, to_date
 
 from butterfree.constants.columns import TIMESTAMP_COLUMN
 
@@ -15,6 +16,60 @@ def column_target_df(spark_context, spark_session):
 def target_df(spark_context, spark_session):
     data = [{"col1": "value", "col2": 123}]
     return spark_session.read.json(spark_context.parallelize(data, 1))
+
+
+@pytest.fixture()
+def incremental_source_df(spark_context, spark_session):
+    data = [
+        {
+            "id": 1,
+            "feature": 100,
+            "date_str": "28/07/2020",
+            "milliseconds": 1595894400000,
+            "year": 2020,
+            "month": 7,
+            "day": 28,
+        },
+        {
+            "id": 1,
+            "feature": 110,
+            "date_str": "29/07/2020",
+            "milliseconds": 1595980800000,
+            "year": 2020,
+            "month": 7,
+            "day": 29,
+        },
+        {
+            "id": 1,
+            "feature": 120,
+            "date_str": "30/07/2020",
+            "milliseconds": 1596067200000,
+            "year": 2020,
+            "month": 7,
+            "day": 30,
+        },
+        {
+            "id": 2,
+            "feature": 150,
+            "date_str": "31/07/2020",
+            "milliseconds": 1596153600000,
+            "year": 2020,
+            "month": 7,
+            "day": 31,
+        },
+        {
+            "id": 2,
+            "feature": 200,
+            "date_str": "01/08/2020",
+            "milliseconds": 1596240000000,
+            "year": 2020,
+            "month": 8,
+            "day": 1,
+        },
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1)).withColumn(
+        "date", to_date(col("date_str"), "dd/MM/yyyy")
+    )
 
 
 @pytest.fixture()

--- a/tests/unit/butterfree/extract/readers/test_incremental_strategy.py
+++ b/tests/unit/butterfree/extract/readers/test_incremental_strategy.py
@@ -1,0 +1,68 @@
+from butterfree.extract.readers import IncrementalStrategy
+
+
+class TestIncrementalStrategy:
+    def test_from_milliseconds(self):
+        # arrange
+        incremental_strategy = IncrementalStrategy().from_milliseconds("ts")
+        target_expression = "date(from_unixtime(ts/ 1000.0)) >= date('2020-01-01')"
+
+        # act
+        result_expression = incremental_strategy.get_expression(start_date="2020-01-01")
+
+        # assert
+        assert target_expression.split() == result_expression.split()
+
+    def test_from_string(self):
+        # arrange
+        incremental_strategy = IncrementalStrategy().from_string(
+            "dt", mask="dd/MM/yyyy"
+        )
+        target_expression = "to_date(dt, 'dd/MM/yyyy') >= date('2020-01-01')"
+
+        # act
+        result_expression = incremental_strategy.get_expression(start_date="2020-01-01")
+
+        # assert
+        assert target_expression.split() == result_expression.split()
+
+    def test_from_year_month_day_partitions(self):
+        # arrange
+        incremental_strategy = IncrementalStrategy().from_year_month_day_partitions(
+            year_column="y", month_column="m", day_column="d"
+        )
+        target_expression = (
+            "date(concat(string(y), "
+            "'-', string(m), "
+            "'-', string(d))) >= date('2020-01-01')"
+        )
+
+        # act
+        result_expression = incremental_strategy.get_expression(start_date="2020-01-01")
+
+        # assert
+        assert target_expression.split() == result_expression.split()
+
+    def test_get_expression_with_just_end_date(self):
+        # arrange
+        incremental_strategy = IncrementalStrategy(column="dt")
+        target_expression = "dt <= date('2020-01-01')"
+
+        # act
+        result_expression = incremental_strategy.get_expression(end_date="2020-01-01")
+
+        # assert
+        assert target_expression.split() == result_expression.split()
+
+    def test_get_expression_with_start_and_end_date(self):
+        # arrange
+        incremental_strategy = IncrementalStrategy(column="dt")
+        target_expression = "dt >= date('2019-12-30') and dt <= date('2020-01-01')"
+
+        # act
+        result_expression = incremental_strategy.get_expression(
+            start_date="2019-12-30", end_date="2020-01-01"
+        )
+
+        # assert
+        assert target_expression.split() == result_expression.split()

--- a/tests/unit/butterfree/extract/readers/test_reader.py
+++ b/tests/unit/butterfree/extract/readers/test_reader.py
@@ -1,7 +1,8 @@
 import pytest
 from pyspark.sql.functions import expr
 
-from butterfree.extract.readers import FileReader
+from butterfree.extract.readers import FileReader, IncrementalStrategy
+from butterfree.testing.dataframe import assert_dataframe_equality
 
 
 def add_value_transformer(df, column, value):
@@ -152,3 +153,59 @@ class TestReader:
 
         # assert
         assert column_target_df.collect() == result_df.collect()
+
+    def test_build_with_incremental_strategy(
+        self, incremental_source_df, spark_client, spark_session
+    ):
+        # arrange
+        readers = [
+            # directly from column
+            FileReader(
+                id="test_1", path="path/to/file", format="format"
+            ).with_incremental_strategy(
+                incremental_strategy=IncrementalStrategy(column="date")
+            ),
+            # from milliseconds
+            FileReader(
+                id="test_2", path="path/to/file", format="format"
+            ).with_incremental_strategy(
+                incremental_strategy=IncrementalStrategy().from_milliseconds(
+                    column_name="milliseconds"
+                )
+            ),
+            # from str
+            FileReader(
+                id="test_3", path="path/to/file", format="format"
+            ).with_incremental_strategy(
+                incremental_strategy=IncrementalStrategy().from_string(
+                    column_name="date_str", mask="dd/MM/yyyy"
+                )
+            ),
+            # from year, month, day partitions
+            FileReader(
+                id="test_4", path="path/to/file", format="format"
+            ).with_incremental_strategy(
+                incremental_strategy=(
+                    IncrementalStrategy().from_year_month_day_partitions()
+                )
+            ),
+        ]
+
+        spark_client.read.return_value = incremental_source_df
+        target_df = incremental_source_df.where(
+            "date >= date('2020-07-29') and date <= date('2020-07-31')"
+        )
+
+        # act
+        for reader in readers:
+            reader.build(
+                client=spark_client, start_date="2020-07-29", end_date="2020-07-31"
+            )
+
+        output_dfs = [
+            spark_session.table(f"test_{i + 1}") for i, _ in enumerate(readers)
+        ]
+
+        # assert
+        for output_df in output_dfs:
+            assert_dataframe_equality(output_df=output_df, target_df=target_df)


### PR DESCRIPTION
## Why? :open_book:
In a incremental run the readers need to be filtered based on an incremental strategy.

## What? :wrench:
- New filter in readers build
- New `IncrementalStrategy` entity
- New tests for `Reader` and `IncrementalStrategy`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
locally with tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points
Depend on this PR: https://github.com/quintoandar/butterfree/pull/220