### PR TITLE
[MLOP-440] Python 3.7 bump and Fixing Dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/')
 
     runs-on: ubuntu-16.04
-    container: rappdw/docker-java-python
+    container: rafaelleino/docker-java-python
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Pipeline:
     runs-on: ubuntu-16.04
-    container: rappdw/docker-java-python
+    container: rafaelleinio/docker-java-python
 
     steps:
     - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ This document describes our guidelines for contributing to Butterfree and its mo
 At the bare minimum you'll need the following for your development
 environment:
 
-1. [Python 3.6.8](http://www.python.org/)
+1. [Python 3.7](http://www.python.org/)
 
 
 It is strongly recommended to also install and use [pyenv](https://github.com/pyenv/pyenv):
@@ -60,7 +60,7 @@ make environment
 
 If you need to configure your development environment in your IDE, notice
 pyenv will store your python under
-`~/.pyenv/versions/3.6.8 butterfree/bin/python`.
+`~/.pyenv/versions/3.7.x butterfree/bin/python`.
 
 ##### Errors
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: environment
 ## create virtual environment for butterfree
 environment:
-	@pyenv install -s 3.6.8
-	@pyenv virtualenv 3.6.8 butterfree
+	@pyenv install -s 3.7.7
+	@pyenv virtualenv 3.7.7 butterfree
 	@pyenv local butterfree
 	@PYTHONPATH=. python -m pip install --upgrade pip
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ _A tool for building feature stores. Transform your raw data into beautiful feat
 
 Made with :heart: by the **MLOps** team from [QuintoAndar](https://github.com/quintoandar/)
 
-This library supports Python version 3.6+ and meant to provide tools for building ETL pipelines for Feature Stores using [Apache Spark](https://spark.apache.org/).
+This library supports Python version 3.7+ and meant to provide tools for building ETL pipelines for Feature Stores using [Apache Spark](https://spark.apache.org/).
 
 The library is centered on the following concetps:
 - **ETL**: central framework to create data pipelines. Spark-based **Extract**, **Transform** and **Load** modules ready to use.
@@ -15,7 +15,7 @@ To understand the main concepts of Feature Store modeling and library main featu
 To learn how to use Butterfree in practice, see [Butterfree's notebook examples](https://github.com/quintoandar/butterfree/tree/master/examples)  
 
 ## Requirements and Installation
-Butterfree depends on **Python 3.6+** and it is **Spark 3.0 ready** :heavy_check_mark:
+Butterfree depends on **Python 3.7+** and it is **Spark 3.0 ready** :heavy_check_mark:
 
 [Python Package Index](https://quintoandar.github.io/python-package-server/) hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==3.1.1
+sphinx-rtd-theme==0.4.3
+sphinxemoji==0.1.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+recommonmark==0.6.0
 Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6

--- a/docs/source/getstart.md
+++ b/docs/source/getstart.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-Butterfree depends on **Python 3.6+** and it is **Spark 3.0 ready**.
+Butterfree depends on **Python 3.7+** and it is **Spark 3.0 ready**.
 
 [Python Package Index](https://quintoandar.github.io/python-package-server/) hosts reference to a pip-installable module of this library, using it is as straightforward as including it on your project's requirements.
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,9 +3,6 @@ h3==3.4.3
 pyarrow==0.15.1
 jupyter==1.0.0
 twine==3.1.1
-Sphinx==3.1.1
-sphinx-rtd-theme==0.4.3
-sphinxemoji==0.1.6
 recommonmark==0.6.0
 mypy==0.782
 pyspark-stubs==3.0.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,11 +1,11 @@
 cmake==3.13.3
 h3==3.4.3
 pyarrow==0.15.1
-pandas==1.0.3
 jupyter==1.0.0
 twine==3.1.1
 Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
+sphinxemoji==0.1.6
 recommonmark==0.6.0
 mypy==0.782
 pyspark-stubs==3.0.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,6 +3,5 @@ h3==3.4.3
 pyarrow==0.15.1
 jupyter==1.0.0
 twine==3.1.1
-recommonmark==0.6.0
 mypy==0.782
 pyspark-stubs==3.0.0

--- a/requirements.lint.txt
+++ b/requirements.lint.txt
@@ -5,4 +5,3 @@ isort<5  # temporary fix
 flake8-docstrings==1.5.0
 flake8-bugbear==20.1.0
 flake8-bandit==2.1.2
-flake8-per-file-ignores==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
 mdutils==1.2.2
-GitPython==3.0.5
-gitdb2==2.0.6
 parameters-validation==1.1.5
 pyspark==3.0.0
-PyYAML==5.3
 cassandra-driver==3.22.0
-sphinxemoji==0.1.6
-typing-extensions==3.7.4.2
+pandas==1.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-cassandra-driver>=3.22.0,<=4.0
-mdutils>=1.2.2,<=2.0
-pandas==1.*
-parameters-validation>=1.1.5,<=2.0
+cassandra-driver>=3.22.0,<4.0
+mdutils>=1.2.2,<2.0
+pandas>=0.24,<1.1
+parameters-validation>=1.1.5,<2.0
 pyspark==3.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-mdutils==1.2.2
-parameters-validation==1.1.5
-pyspark==3.0.0
-cassandra-driver==3.22.0
-pandas==1.0.3
+cassandra-driver>=3.22.0,<=4.0
+mdutils>=1.2.2,<=2.0
+pandas==1.*
+parameters-validation>=1.1.5,<=2.0
+pyspark==3.*

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setup(
     author="QuintoAndar",
     install_requires=requirements,
     extras_require={"h3": ["cmake==3.16.3", "h3==3.4.2"]},
-    python_requires=">=3.6, <4",
+    python_requires=">=3.7, <4",
 )


### PR DESCRIPTION
## Why? :open_book:
We use some typing features from Python 3.7 and our environment uses this version too. In Python 3.6 images some typing features were not working properly.

## What? :wrench:
- New docker image for the CI using Python 3.7
- Removing unused dependencies/imports
- Adjusting references to Python Version

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Unit/Integration tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
