### PR TITLE
Fix container name in Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/')
 
     runs-on: ubuntu-16.04
-    container: rafaelleino/docker-java-python
+    container: rafaelleinio/docker-java-python
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Why? :open_book:
Container's name was wrong in Publish.yml file.

## What? :wrench:
- Workflow

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
