### PR TITLE
[FIX] Downgrade Python Version in Pyenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: environment
 ## create virtual environment for butterfree
 environment:
-	@pyenv install -s 3.7.7
-	@pyenv virtualenv 3.7.7 butterfree
+	@pyenv install -s 3.7.6
+	@pyenv virtualenv 3.7.6 butterfree
 	@pyenv local butterfree
 	@PYTHONPATH=. python -m pip install --upgrade pip
 


### PR DESCRIPTION
## Why? :open_book:
```make environment``` command was not running, so this a fix.

## What? :wrench:
Homebrew Pyenv has not provided a ```3.7.7``` version, therefore it was downgraded to ```3.7.6```. 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Locally.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

