### PR TITLE
[MLOP-401] Define date boundaries within the scope of the writing operation

### DIFF
--- a/butterfree/dataframe_service/__init__.py
+++ b/butterfree/dataframe_service/__init__.py
@@ -1,4 +1,5 @@
 """Dataframe optimization components regarding Butterfree."""
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
 from butterfree.dataframe_service.repartition import repartition_df, repartition_sort_df
 
-__all__ = ["repartition_df", "repartition_sort_df"]
+__all__ = ["IncrementalStrategy", "repartition_df", "repartition_sort_df"]

--- a/butterfree/dataframe_service/incremental_strategy.py
+++ b/butterfree/dataframe_service/incremental_strategy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pyspark.sql import DataFrame
+
 
 class IncrementalStrategy:
     """Define an incremental strategy to be used on data sources.
@@ -96,3 +98,14 @@ class IncrementalStrategy:
                 expression += f" and {self.column} <= date('{end_date}')"
             return expression
         return f"{self.column} <= date('{end_date}')"
+
+    def filter_with_incremental_strategy(
+        self, dataframe: DataFrame, start_date: str = None, end_date: str = None
+    ) -> DataFrame:
+        return (
+            dataframe.where(
+                self.get_expression(start_date=start_date, end_date=end_date)
+            )
+            if start_date or end_date
+            else dataframe
+        )

--- a/butterfree/extract/readers/__init__.py
+++ b/butterfree/extract/readers/__init__.py
@@ -1,7 +1,6 @@
 """The Reader Component of a Source."""
 from butterfree.extract.readers.file_reader import FileReader
-from butterfree.extract.readers.incremental_strategy import IncrementalStrategy
 from butterfree.extract.readers.kafka_reader import KafkaReader
 from butterfree.extract.readers.table_reader import TableReader
 
-__all__ = ["FileReader", "KafkaReader", "TableReader", "IncrementalStrategy"]
+__all__ = ["FileReader", "KafkaReader", "TableReader"]

--- a/butterfree/extract/readers/reader.py
+++ b/butterfree/extract/readers/reader.py
@@ -9,7 +9,7 @@ from typing import Callable, List
 from pyspark.sql import DataFrame
 
 from butterfree.clients import SparkClient
-from butterfree.extract.readers.incremental_strategy import IncrementalStrategy
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
 
 
 class Reader(ABC):
@@ -102,10 +102,11 @@ class Reader(ABC):
         """
         column_selection_df = self._select_columns(columns, client)
         transformed_df = self._apply_transformations(column_selection_df)
-        filtered_df = self._filter_with_incremental_strategy(
-            transformed_df, start_date, end_date
-        )
-        filtered_df.createOrReplaceTempView(self.id)
+        if start_date or end_date:
+            transformed_df = self.incremental_strategy.filter_with_incremental_strategy(
+                transformed_df, start_date, end_date
+            )
+        transformed_df.createOrReplaceTempView(self.id)
 
     def _select_columns(self, columns: List[str], client: SparkClient) -> DataFrame:
         df = self.consume(client)
@@ -127,17 +128,4 @@ class Reader(ABC):
             ),
             self.transformations,
             df,
-        )
-
-    def _filter_with_incremental_strategy(
-        self, df: DataFrame, start_date: str, end_date: str
-    ) -> DataFrame:
-        return (
-            df.where(
-                self.incremental_strategy.get_expression(
-                    start_date=start_date, end_date=end_date
-                )
-            )
-            if self.incremental_strategy
-            else df
         )

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -67,13 +67,17 @@ class Source:
 
         Args:
             client: client responsible for connecting to Spark session.
+            start_date: start date related to the extract layer.
+            end_date:  end date regarding the extract layer.
 
         Returns:
             DataFrame with the query result against all readers.
 
         """
         for reader in self.readers:
-            reader.build(client)  # create temporary views for each reader
+            reader.build(
+                client=client, start_date=start_date, end_date=end_date
+            )  # create temporary views for each reader
 
         dataframe = client.sql(self.query)
 

--- a/butterfree/load/sink.py
+++ b/butterfree/load/sink.py
@@ -81,7 +81,12 @@ class Sink:
             )
 
     def flush(
-        self, feature_set: FeatureSet, dataframe: DataFrame, spark_client: SparkClient
+        self,
+        feature_set: FeatureSet,
+        dataframe: DataFrame,
+        spark_client: SparkClient,
+        start_date: str = None,
+        end_date: str = None,
     ) -> List[StreamingQuery]:
         """Trigger a write job in all the defined Writers.
 
@@ -89,6 +94,8 @@ class Sink:
             dataframe: spark dataframe containing data from a feature set.
             feature_set: object processed with feature set metadata.
             spark_client: client used to run a query.
+            start_date: start date related to the load layer.
+            end_date: end date related to the load layer.
 
         Returns:
             Streaming handlers for each defined writer, if writing streaming dfs.
@@ -98,7 +105,11 @@ class Sink:
 
         handlers = [
             writer.write(
-                feature_set=feature_set, dataframe=dataframe, spark_client=spark_client
+                feature_set=feature_set,
+                dataframe=dataframe,
+                spark_client=spark_client,
+                start_date=start_date,
+                end_date=end_date,
             )
             for writer in self.writers
         ]

--- a/butterfree/load/writers/online_feature_store_writer.py
+++ b/butterfree/load/writers/online_feature_store_writer.py
@@ -76,7 +76,7 @@ class OnlineFeatureStoreWriter(Writer):
         db_config=None,
         debug_mode: bool = False,
         write_to_entity=False,
-        incremental_strategy: IncrementalStrategy = None
+        incremental_strategy: IncrementalStrategy = None,
     ):
         self.db_config = db_config or CassandraConfig()
         self.debug_mode = debug_mode

--- a/butterfree/load/writers/writer.py
+++ b/butterfree/load/writers/writer.py
@@ -1,10 +1,13 @@
 """Writer entity."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 from pyspark.sql.dataframe import DataFrame
 
 from butterfree.clients import SparkClient
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
 from butterfree.transform import FeatureSet
 
 
@@ -16,9 +19,17 @@ class Writer(ABC):
 
     """
 
+    def __init__(self, incremental_strategy: IncrementalStrategy = None):
+        self.incremental_strategy = incremental_strategy
+
     @abstractmethod
     def write(
-        self, feature_set: FeatureSet, dataframe: DataFrame, spark_client: SparkClient,
+        self,
+        feature_set: FeatureSet,
+        dataframe: DataFrame,
+        spark_client: SparkClient,
+        start_date: str = None,
+        end_date: str = None,
     ):
         """Loads the data from a feature set into the Feature Store.
 
@@ -28,8 +39,25 @@ class Writer(ABC):
             feature_set: object processed with feature set metadata.
             dataframe: Spark dataframe containing data from a feature set.
             spark_client: client for Spark connections with external services.
+            start_date: start date regarding the load layer.
+            end_date: end date related to the load layer.
 
         """
+
+    def with_incremental_strategy(
+        self, incremental_strategy: IncrementalStrategy
+    ) -> Writer:
+        """Define the incremental strategy for the Writer.
+
+        Args:
+            incremental_strategy: definition of the incremental strategy.
+
+        Returns:
+            Writer with defined incremental strategy.
+
+        """
+        self.incremental_strategy = incremental_strategy
+        return self
 
     @abstractmethod
     def validate(

--- a/butterfree/pipelines/feature_set_pipeline.py
+++ b/butterfree/pipelines/feature_set_pipeline.py
@@ -215,6 +215,8 @@ class FeatureSetPipeline:
             dataframe=dataframe,
             feature_set=self.feature_set,
             spark_client=self.spark_client,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         if not dataframe.isStreaming:

--- a/tests/unit/butterfree/dataframe_service/test_incremental_strategy.py
+++ b/tests/unit/butterfree/dataframe_service/test_incremental_strategy.py
@@ -1,4 +1,4 @@
-from butterfree.extract.readers import IncrementalStrategy
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
 
 
 class TestIncrementalStrategy:

--- a/tests/unit/butterfree/extract/readers/test_reader.py
+++ b/tests/unit/butterfree/extract/readers/test_reader.py
@@ -1,7 +1,8 @@
 import pytest
 from pyspark.sql.functions import expr
 
-from butterfree.extract.readers import FileReader, IncrementalStrategy
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
+from butterfree.extract.readers import FileReader
 from butterfree.testing.dataframe import assert_dataframe_equality
 
 

--- a/tests/unit/butterfree/load/conftest.py
+++ b/tests/unit/butterfree/load/conftest.py
@@ -44,6 +44,37 @@ def feature_set_dataframe(spark_context, spark_session):
 
 
 @fixture
+def filtered_historical_feature_set_dataframe(spark_context, spark_session):
+    data = [
+        {
+            "feature": 100,
+            "id": 1,
+            TIMESTAMP_COLUMN: "2019-12-31",
+            columns.PARTITION_YEAR: 2019,
+            columns.PARTITION_MONTH: 12,
+            columns.PARTITION_DAY: 31,
+        },
+        {
+            "id": 2,
+            TIMESTAMP_COLUMN: "2019-12-31",
+            "feature": 200,
+            columns.PARTITION_YEAR: 2019,
+            columns.PARTITION_MONTH: 12,
+            columns.PARTITION_DAY: 31,
+        },
+        {
+            "id": 1,
+            TIMESTAMP_COLUMN: "2020-01-15",
+            "feature": 110,
+            columns.PARTITION_YEAR: 2020,
+            columns.PARTITION_MONTH: 1,
+            columns.PARTITION_DAY: 15,
+        },
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))
+
+
+@fixture
 def historical_feature_set_dataframe(spark_context, spark_session):
     data = [
         {
@@ -84,6 +115,15 @@ def historical_feature_set_dataframe(spark_context, spark_session):
 
 @fixture
 def latest_feature_set_dataframe(spark_context, spark_session):
+    data = [
+        {"id": 2, TIMESTAMP_COLUMN: "2019-12-31", "feature": 200},
+        {"id": 1, TIMESTAMP_COLUMN: "2020-02-01", "feature": 120},
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))
+
+
+@fixture
+def filtered_latest_feature_set_dataframe(spark_context, spark_session):
     data = [
         {"id": 2, TIMESTAMP_COLUMN: "2019-12-31", "feature": 200},
         {"id": 1, TIMESTAMP_COLUMN: "2020-02-01", "feature": 120},

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -5,6 +5,7 @@ import pytest
 from pyspark.sql.functions import spark_partition_id
 
 from butterfree.clients import SparkClient
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
 from butterfree.load.writers import HistoricalFeatureStoreWriter
 from butterfree.testing.dataframe import assert_dataframe_equality
 
@@ -32,6 +33,42 @@ class TestHistoricalFeatureStoreWriter:
 
         # then
         assert_dataframe_equality(historical_feature_set_dataframe, result_df)
+
+        assert (
+            writer.db_config.format_ == spark_client.write_table.call_args[1]["format_"]
+        )
+        assert writer.db_config.mode == spark_client.write_table.call_args[1]["mode"]
+        assert (
+            writer.PARTITION_BY == spark_client.write_table.call_args[1]["partition_by"]
+        )
+        assert feature_set.name == spark_client.write_table.call_args[1]["table_name"]
+
+    def test_write_with_incremental_strategy(
+        self,
+        feature_set_dataframe,
+        filtered_historical_feature_set_dataframe,
+        mocker,
+        feature_set,
+    ):
+        # given
+        spark_client = mocker.stub("spark_client")
+        spark_client.write_table = mocker.stub("write_table")
+        writer = HistoricalFeatureStoreWriter().with_incremental_strategy(
+            IncrementalStrategy(column="timestamp")
+        )
+
+        # when
+        writer.write(
+            feature_set=feature_set,
+            dataframe=feature_set_dataframe,
+            spark_client=spark_client,
+            start_date="2019-12-31",
+            end_date="2020-01-31",
+        )
+        result_df = spark_client.write_table.call_args[1]["dataframe"]
+
+        # then
+        assert_dataframe_equality(filtered_historical_feature_set_dataframe, result_df)
 
         assert (
             writer.db_config.format_ == spark_client.write_table.call_args[1]["format_"]


### PR DESCRIPTION
## Why? :open_book:
We defined date boundaries within the scope of the load layer.

## What? :wrench:
Added methods to enable data filtering.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
