### PR TITLE
Fix docs.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ recommonmark==0.6.0
 Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
+typing-extensions==3.7.4.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,9 +28,9 @@ copyright = "2020, QuintoAndar"
 author = "QuintoAndar"
 
 # The short X.Y version
-version = "0.10.3"
+version = "1.0"
 # The full version, including alpha/beta/rc tags
-release = "0.10.3"
+release = "1.0.2"
 
 
 # -- General configuration ---------------------------------------------------
@@ -46,7 +46,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "recommonmark",
     "sphinx_rtd_theme",
-    "sphinx.ext.githubpages",
     "sphinx.ext.napoleon",
     "sphinx.ext.coverage",
     "sphinxemoji.sphinxemoji",


### PR DESCRIPTION
## Why? :open_book:
Some modules of our documentation are blank.

![image](https://user-images.githubusercontent.com/44944954/90183132-5c7a5300-dd89-11ea-93b0-658ff13d6663.png)

## What? :wrench:
- Docs Requirements

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Attention Points :warning:
It is possible that more errors will appear after fixing this error.
