### PR TITLE
Fix Docs - Add more dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,7 @@ Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2
+cmake==3.13.3
+h3==3.4.3
+pyarrow==0.15.1
+


### PR DESCRIPTION
## Why? :open_book:
Some modules of our documentation are blank.

![image](https://user-images.githubusercontent.com/44944954/90183132-5c7a5300-dd89-11ea-93b0-658ff13d6663.png)

## What? :wrench:
- Docs Requirements

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Attention Points :warning:
It is possible that more errors will appear after fixing this error.
