### PR TITLE
[MLOP-401] Define date boundaries within the scope of the writing operation

### DIFF
--- a/butterfree/dataframe_service/__init__.py
+++ b/butterfree/dataframe_service/__init__.py
@@ -1,4 +1,5 @@
 """Dataframe optimization components regarding Butterfree."""
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
 from butterfree.dataframe_service.repartition import repartition_df, repartition_sort_df
 
-__all__ = ["repartition_df", "repartition_sort_df"]
+__all__ = ["IncrementalStrategy", "repartition_df", "repartition_sort_df"]

--- a/butterfree/dataframe_service/incremental_strategy.py
+++ b/butterfree/dataframe_service/incremental_strategy.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pyspark.sql import DataFrame
+
 
 class IncrementalStrategy:
     """Define an incremental strategy to be used on data sources.
@@ -96,3 +98,25 @@ class IncrementalStrategy:
                 expression += f" and {self.column} <= date('{end_date}')"
             return expression
         return f"{self.column} <= date('{end_date}')"
+
+    def filter_with_incremental_strategy(
+        self, dataframe: DataFrame, start_date: str = None, end_date: str = None
+    ) -> DataFrame:
+        """Filters the dataframe according to the date boundaries.
+
+        Args:
+            dataframe: dataframe that will be filtered.
+            start_date: date lower bound to use in the filter.
+            end_date: date upper bound to use in the filter.
+
+        Returns:
+            Filtered dataframe based on defined time boundaries.
+
+        """
+        return (
+            dataframe.where(
+                self.get_expression(start_date=start_date, end_date=end_date)
+            )
+            if start_date or end_date
+            else dataframe
+        )

--- a/butterfree/extract/readers/__init__.py
+++ b/butterfree/extract/readers/__init__.py
@@ -1,7 +1,6 @@
 """The Reader Component of a Source."""
 from butterfree.extract.readers.file_reader import FileReader
-from butterfree.extract.readers.incremental_strategy import IncrementalStrategy
 from butterfree.extract.readers.kafka_reader import KafkaReader
 from butterfree.extract.readers.table_reader import TableReader
 
-__all__ = ["FileReader", "KafkaReader", "TableReader", "IncrementalStrategy"]
+__all__ = ["FileReader", "KafkaReader", "TableReader"]

--- a/butterfree/pipelines/feature_set_pipeline.py
+++ b/butterfree/pipelines/feature_set_pipeline.py
@@ -192,10 +192,10 @@ class FeatureSetPipeline:
         soon. Use only if strictly necessary.
 
         """
-        start_date = self.feature_set.define_start_date(start_date)
-
         dataframe = self.source.construct(
-            client=self.spark_client, start_date=start_date, end_date=end_date
+            client=self.spark_client,
+            start_date=self.feature_set.define_start_date(start_date),
+            end_date=end_date,
         )
 
         if partition_by:
@@ -207,6 +207,7 @@ class FeatureSetPipeline:
         dataframe = self.feature_set.construct(
             dataframe=dataframe,
             client=self.spark_client,
+            start_date=start_date,
             end_date=end_date,
             num_processors=num_processors,
         )

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -393,6 +393,7 @@ class FeatureSet:
         self,
         dataframe: DataFrame,
         client: SparkClient,
+        start_date: str = None,
         end_date: str = None,
         num_processors: int = None,
     ) -> DataFrame:
@@ -404,7 +405,8 @@ class FeatureSet:
         Args:
             dataframe: input dataframe to be transformed by the features.
             client: client responsible for connecting to Spark session.
-            end_date: user defined base date.
+            start_date: user defined start date.
+            end_date: user defined end date.
             num_processors: cluster total number of processors for repartitioning.
 
         Returns:

--- a/tests/integration/butterfree/transform/conftest.py
+++ b/tests/integration/butterfree/transform/conftest.py
@@ -395,3 +395,46 @@ def rolling_windows_output_feature_set_dataframe_base_date(
     df = df.withColumn(TIMESTAMP_COLUMN, df.origin_ts.cast(DataType.TIMESTAMP.spark))
 
     return df
+
+
+@fixture
+def feature_set_dates_dataframe(spark_context, spark_session):
+    data = [
+        {"id": 1, "ts": "2016-04-11 11:31:11", "feature": 200},
+        {"id": 1, "ts": "2016-04-12 11:44:12", "feature": 300},
+        {"id": 1, "ts": "2016-04-13 11:46:24", "feature": 400},
+        {"id": 1, "ts": "2016-04-14 12:03:21", "feature": 500},
+    ]
+    df = spark_session.read.json(spark_context.parallelize(data, 1))
+    df = df.withColumn(TIMESTAMP_COLUMN, df.ts.cast(DataType.TIMESTAMP.spark))
+    df = df.withColumn("ts", df.ts.cast(DataType.TIMESTAMP.spark))
+
+    return df
+
+
+@fixture
+def rolling_windows_output_date_boundaries(spark_context, spark_session):
+    data = [
+        {
+            "id": 1,
+            "ts": "2016-04-11 00:00:00",
+            "feature__avg_over_1_day_rolling_windows": None,
+            "feature__avg_over_1_week_rolling_windows": None,
+            "feature__stddev_pop_over_1_day_rolling_windows": None,
+            "feature__stddev_pop_over_1_week_rolling_windows": None,
+        },
+        {
+            "id": 1,
+            "ts": "2016-04-12 00:00:00",
+            "feature__avg_over_1_day_rolling_windows": 200.0,
+            "feature__avg_over_1_week_rolling_windows": 200.0,
+            "feature__stddev_pop_over_1_day_rolling_windows": 0.0,
+            "feature__stddev_pop_over_1_week_rolling_windows": 0.0,
+        },
+    ]
+    df = spark_session.read.json(
+        spark_context.parallelize(data).map(lambda x: json.dumps(x))
+    )
+    df = df.withColumn(TIMESTAMP_COLUMN, df.ts.cast(DataType.TIMESTAMP.spark))
+
+    return df

--- a/tests/integration/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/integration/butterfree/transform/test_aggregated_feature_set.py
@@ -241,3 +241,53 @@ class TestAggregatedFeatureSet:
 
         # assert
         assert_dataframe_equality(output_df, target_df_pivot_agg)
+
+    def test_construct_rolling_windows_with_date_boundaries(
+        self, feature_set_dates_dataframe, rolling_windows_output_date_boundaries,
+    ):
+        # given
+
+        spark_client = SparkClient()
+
+        # arrange
+
+        feature_set = AggregatedFeatureSet(
+            name="feature_set",
+            entity="entity",
+            description="description",
+            features=[
+                Feature(
+                    name="feature",
+                    description="test",
+                    transformation=AggregatedTransform(
+                        functions=[
+                            Function(F.avg, DataType.DOUBLE),
+                            Function(F.stddev_pop, DataType.DOUBLE),
+                        ],
+                    ),
+                ),
+            ],
+            keys=[
+                KeyFeature(
+                    name="id",
+                    description="The user's Main ID or device ID",
+                    dtype=DataType.INTEGER,
+                )
+            ],
+            timestamp=TimestampFeature(),
+        ).with_windows(definitions=["1 day", "1 week"])
+
+        # act
+        output_df = feature_set.construct(
+            feature_set_dates_dataframe,
+            client=spark_client,
+            start_date="2016-04-11",
+            end_date="2016-04-12",
+        ).orderBy("timestamp")
+
+        target_df = rolling_windows_output_date_boundaries.orderBy(
+            feature_set.timestamp_column
+        ).select(feature_set.columns)
+
+        # assert
+        assert_dataframe_equality(output_df, target_df)

--- a/tests/unit/butterfree/dataframe_service/test_incremental_strategy.py
+++ b/tests/unit/butterfree/dataframe_service/test_incremental_strategy.py
@@ -1,4 +1,4 @@
-from butterfree.extract.readers import IncrementalStrategy
+from butterfree.dataframe_service import IncrementalStrategy
 
 
 class TestIncrementalStrategy:

--- a/tests/unit/butterfree/extract/readers/test_reader.py
+++ b/tests/unit/butterfree/extract/readers/test_reader.py
@@ -1,7 +1,8 @@
 import pytest
 from pyspark.sql.functions import expr
 
-from butterfree.extract.readers import FileReader, IncrementalStrategy
+from butterfree.dataframe_service import IncrementalStrategy
+from butterfree.extract.readers import FileReader
 from butterfree.testing.dataframe import assert_dataframe_equality
 
 


### PR DESCRIPTION
## Why? :open_book:
We defined date boundaries within the scope of the transformation layer.

## What? :wrench:
Added methods to enable data filtering.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit and Integration tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
