### PR TITLE
[MLOP-405] Spark Client Add Partitions Method

### DIFF
--- a/butterfree/clients/spark_client.py
+++ b/butterfree/clients/spark_client.py
@@ -225,3 +225,41 @@ class SparkClient(AbstractClient):
         if not dataframe.isStreaming:
             return dataframe.createOrReplaceTempView(name)
         return dataframe.writeStream.format("memory").queryName(name).start()
+
+    def add_table_partitions(
+        self, partitions: List[dict], table, database=None
+    ) -> None:
+        """Add partitions to an existing table.
+
+        Args:
+            partitions: partitions to add to the table.
+                It's expected a list of partition dicts to add to the table.
+                Example: `[{"year": 2020, "month": 8, "day": 14}, ...]`
+            table: table to add the partitions.
+            database: name of the database where the table is saved.
+
+        """
+        for partition_dict in partitions:
+            if not all(
+                (isinstance(value, str) or isinstance(value, int))
+                for value in partition_dict
+            ):
+                raise ValueError("Partition values must be string or int.")
+        database_expr = f"`{database}`." or ""
+        key_values_expr = [
+            ", ".join(
+                [
+                    "{} = {}".format(k, v)
+                    if not isinstance(v, str)
+                    else "{} = '{}'".format(k, v)
+                    for k, v in partition.items()
+                ]
+            )
+            for partition in partitions
+        ]
+        partitions_expr = " ".join(f"PARTITION ( {expr} )" for expr in key_values_expr)
+        command = (
+            f"ALTER TABLE {database_expr}`{table}` ADD IF NOT EXISTS {partitions_expr}"
+        )
+
+        self.conn.sql(command)

--- a/butterfree/clients/spark_client.py
+++ b/butterfree/clients/spark_client.py
@@ -241,10 +241,17 @@ class SparkClient(AbstractClient):
         """
         for partition_dict in partitions:
             if not all(
-                (isinstance(value, str) or isinstance(value, int))
-                for value in partition_dict
+                (
+                    isinstance(key, str)
+                    and (isinstance(value, str) or isinstance(value, int))
+                )
+                for key, value in partition_dict.items()
             ):
-                raise ValueError("Partition values must be string or int.")
+                raise ValueError(
+                    "Partition keys must be column names "
+                    "and values must be string or int."
+                )
+
         database_expr = f"`{database}`." or ""
         key_values_expr = [
             ", ".join(

--- a/butterfree/clients/spark_client.py
+++ b/butterfree/clients/spark_client.py
@@ -227,7 +227,7 @@ class SparkClient(AbstractClient):
         return dataframe.writeStream.format("memory").queryName(name).start()
 
     def add_table_partitions(
-        self, partitions: List[dict], table, database=None
+        self, partitions: List[Dict[str, Any]], table: str, database: str = None
     ) -> None:
         """Add partitions to an existing table.
 

--- a/tests/unit/butterfree/clients/conftest.py
+++ b/tests/unit/butterfree/clients/conftest.py
@@ -46,6 +46,13 @@ def mocked_stream_df() -> Mock:
     return mock
 
 
+@pytest.fixture()
+def mock_spark_sql() -> Mock:
+    mock = Mock()
+    mock.sql = mock
+    return mock
+
+
 @pytest.fixture
 def cassandra_client() -> CassandraClient:
     return CassandraClient(

--- a/tests/unit/butterfree/clients/test_spark_client.py
+++ b/tests/unit/butterfree/clients/test_spark_client.py
@@ -252,3 +252,26 @@ class TestSparkClient:
 
         # assert
         assert_dataframe_equality(target_df, result_df)
+
+    def test_add_table_partitions(self, mock_spark_sql: Mock):
+        # arrange
+        target_command = (
+            f"ALTER TABLE `db`.`table` ADD IF NOT EXISTS "
+            f"PARTITION ( year = 2020, month = 8, day = 14 ) "
+            f"PARTITION ( year = 2020, month = 8, day = 15 ) "
+            f"PARTITION ( year = 2020, month = 8, day = 16 )"
+        )
+
+        spark_client = SparkClient()
+        spark_client._session = mock_spark_sql
+        partitions = [
+            {"year": 2020, "month": 8, "day": 14},
+            {"year": 2020, "month": 8, "day": 15},
+            {"year": 2020, "month": 8, "day": 16},
+        ]
+
+        # act
+        spark_client.add_table_partitions(partitions, "table", "db")
+
+        # assert
+        mock_spark_sql.assert_called_once_with(target_command)

--- a/tests/unit/butterfree/clients/test_spark_client.py
+++ b/tests/unit/butterfree/clients/test_spark_client.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, Optional, Union
 from unittest.mock import Mock
 
@@ -275,3 +276,20 @@ class TestSparkClient:
 
         # assert
         mock_spark_sql.assert_called_once_with(target_command)
+
+    @pytest.mark.parametrize(
+        "partition",
+        [
+            [{"float_partition": 2.72}],
+            [{123: 2020}],
+            [{"date": datetime(year=2020, month=8, day=18)}],
+        ],
+    )
+    def test_add_invalid_partitions(self, mock_spark_sql: Mock, partition):
+        # arrange
+        spark_client = SparkClient()
+        spark_client._session = mock_spark_sql
+
+        # act and assert
+        with pytest.raises(ValueError):
+            spark_client.add_table_partitions(partition, "table", "db")


### PR DESCRIPTION
## Why? :open_book:
After writing only the daily dataset we need a way to add the daily partitions to Spark's metastore.

## What? :wrench:
New method `add_table_partitions` on `SparkClient`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Locally and in this notebook: https://dbc-eea99378-83b2.cloud.databricks.com/?o=3542631183402105#notebook/403249991677936/command/2139563602263960

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
I didn't create a new entity to hold key-value data from partitions because someone can use the method to add partitions from any column, not just year/month/day. So maybe in this case, for initial implementation, a generalist data structure like a list of dicts can handle this problem well. I think the Docstring that I've written shows an example and it's clear to the user how he is supposed to use this method. But I'm open to ideas :rocket: :rocket: :rocket: 
