### PR TITLE
[MLOP-456] Extract Partition Values

### DIFF
--- a/butterfree/dataframe_service/__init__.py
+++ b/butterfree/dataframe_service/__init__.py
@@ -1,5 +1,11 @@
 """Dataframe optimization components regarding Butterfree."""
 from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
+from butterfree.dataframe_service.partitioning import extract_partition_values
 from butterfree.dataframe_service.repartition import repartition_df, repartition_sort_df
 
-__all__ = ["IncrementalStrategy", "repartition_df", "repartition_sort_df"]
+__all__ = [
+    "extract_partition_values",
+    "IncrementalStrategy",
+    "repartition_df",
+    "repartition_sort_df",
+]

--- a/butterfree/dataframe_service/partitioning.py
+++ b/butterfree/dataframe_service/partitioning.py
@@ -6,20 +6,20 @@ from pyspark.sql import DataFrame
 
 
 def extract_partition_values(
-    dataframe: DataFrame, patition_columns: List[str]
+    dataframe: DataFrame, partition_columns: List[str]
 ) -> List[Dict[str, Any]]:
     """Extract distinct partition values from a given dataframe.
 
     Args:
         dataframe: dataframe from where to extract partition values.
-        patition_columns: name of partition columns presented on the dataframe.
+        partition_columns: name of partition columns presented on the dataframe.
 
     Returns:
         distinct partition values.
 
     """
     return (
-        dataframe.select(*patition_columns)
+        dataframe.select(*partition_columns)
         .distinct()
         .rdd.map(lambda row: row.asDict(True))
         .collect()

--- a/butterfree/dataframe_service/partitioning.py
+++ b/butterfree/dataframe_service/partitioning.py
@@ -1,0 +1,26 @@
+"""Module defining partitioning methods."""
+
+from typing import Any, Dict, List
+
+from pyspark.sql import DataFrame
+
+
+def extract_partition_values(
+    dataframe: DataFrame, patition_columns: List[str]
+) -> List[Dict[str, Any]]:
+    """Extract distinct partition values from a given dataframe.
+
+    Args:
+        dataframe: dataframe from where to extract partition values.
+        patition_columns: name of partition columns presented on the dataframe.
+
+    Returns:
+        distinct partition values.
+
+    """
+    return (
+        dataframe.select(*patition_columns)
+        .distinct()
+        .rdd.map(lambda row: row.asDict(True))
+        .collect()
+    )

--- a/tests/unit/butterfree/dataframe_service/conftest.py
+++ b/tests/unit/butterfree/dataframe_service/conftest.py
@@ -25,3 +25,17 @@ def input_df(spark_context, spark_session):
     return spark_session.read.json(
         spark_context.parallelize(data, 1), schema="timestamp timestamp"
     )
+
+
+@pytest.fixture()
+def test_partitioning_input_df(spark_context, spark_session):
+    data = [
+        {"feature": 1, "year": 2009, "month": 8, "day": 20},
+        {"feature": 2, "year": 2009, "month": 8, "day": 20},
+        {"feature": 3, "year": 2020, "month": 8, "day": 20},
+        {"feature": 4, "year": 2020, "month": 9, "day": 20},
+        {"feature": 5, "year": 2020, "month": 9, "day": 20},
+        {"feature": 6, "year": 2020, "month": 8, "day": 20},
+        {"feature": 7, "year": 2020, "month": 8, "day": 21},
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))

--- a/tests/unit/butterfree/dataframe_service/test_partitioning.py
+++ b/tests/unit/butterfree/dataframe_service/test_partitioning.py
@@ -1,0 +1,20 @@
+from butterfree.dataframe_service import extract_partition_values
+
+
+class TestPartitioning:
+    def test_extract_partition_values(self, test_partitioning_input_df):
+        # arrange
+        target_values = [
+            {"year": 2009, "month": 8, "day": 20},
+            {"year": 2020, "month": 8, "day": 20},
+            {"year": 2020, "month": 9, "day": 20},
+            {"year": 2020, "month": 8, "day": 21},
+        ]
+
+        # act
+        result_values = extract_partition_values(
+            test_partitioning_input_df, patition_columns=["year", "month", "day"]
+        )
+
+        # assert
+        assert result_values == target_values

--- a/tests/unit/butterfree/dataframe_service/test_partitioning.py
+++ b/tests/unit/butterfree/dataframe_service/test_partitioning.py
@@ -13,7 +13,7 @@ class TestPartitioning:
 
         # act
         result_values = extract_partition_values(
-            test_partitioning_input_df, patition_columns=["year", "month", "day"]
+            test_partitioning_input_df, partition_columns=["year", "month", "day"]
         )
 
         # assert


### PR DESCRIPTION
## Why? :open_book:
For the incremental feature, we need to add the partitions after the load. Having a method to extract automatically these partition values from the dataframe will help.

## What? :wrench:
- New method on `dataframe_service` -> `extract_partition_values`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
locally with tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.