### PR TITLE
[MLOP-436] Deal with execution_date parameter

### DIFF
--- a/butterfree/dataframe_service/incremental_strategy.py
+++ b/butterfree/dataframe_service/incremental_strategy.py
@@ -32,7 +32,7 @@ class IncrementalStrategy:
             `IncrementalStrategy` with the defined column expression.
 
         """
-        return IncrementalStrategy(column=f"date(from_unixtime({column_name}/ 1000.0))")
+        return IncrementalStrategy(column=f"from_unixtime({column_name}/ 1000.0)")
 
     def from_string(self, column_name: str, mask: str = None) -> IncrementalStrategy:
         """Create a column expression from ts column defined as a simple string.
@@ -65,9 +65,9 @@ class IncrementalStrategy:
 
         """
         return IncrementalStrategy(
-            column=f"date(concat(string({year_column}), "
+            column=f"concat(string({year_column}), "
             f"'-', string({month_column}), "
-            f"'-', string({day_column})))"
+            f"'-', string({day_column}))"
         )
 
     def get_expression(self, start_date: str = None, end_date: str = None) -> str:
@@ -93,11 +93,11 @@ class IncrementalStrategy:
         if not (start_date or end_date):
             raise ValueError("Both arguments start_date and end_date can't be None.")
         if start_date:
-            expression = f"{self.column} >= date('{start_date}')"
+            expression = f"date({self.column}) >= date('{start_date}')"
             if end_date:
-                expression += f" and {self.column} <= date('{end_date}')"
+                expression += f" and date({self.column}) <= date('{end_date}')"
             return expression
-        return f"{self.column} <= date('{end_date}')"
+        return f"date({self.column}) <= date('{end_date}')"
 
     def filter_with_incremental_strategy(
         self, dataframe: DataFrame, start_date: str = None, end_date: str = None

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -60,13 +60,18 @@ class Source:
         """Construct an entry point dataframe for a feature set.
 
         This method will assemble multiple readers, by building each one and
-        querying them using a Spark SQL.
+        querying them using a Spark SQL. It's important to highlight that in
+        order to filter a dataframe regarding date boundaries, it's important
+        to define a IncrementalStrategy, otherwise your data will not be filtered.
+        Besides, both start and end dates parameters are optional.
 
         After that, there's the caching of the dataframe, however since cache()
         in Spark is lazy, an action is triggered in order to force persistence.
 
         Args:
             client: client responsible for connecting to Spark session.
+            start_date: user defined start date for filtering.
+            end_date: user defined end date for filtering.
 
         Returns:
             DataFrame with the query result against all readers.

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -73,7 +73,9 @@ class Source:
 
         """
         for reader in self.readers:
-            reader.build(client)  # create temporary views for each reader
+            reader.build(
+                client=client, start_date=start_date, end_date=end_date
+            )  # create temporary views for each reader
 
         dataframe = client.sql(self.query)
 

--- a/butterfree/pipelines/feature_set_pipeline.py
+++ b/butterfree/pipelines/feature_set_pipeline.py
@@ -1,4 +1,5 @@
 """FeatureSetPipeline entity."""
+from datetime import datetime, timedelta
 from typing import List
 
 from butterfree.clients import SparkClient
@@ -224,3 +225,36 @@ class FeatureSetPipeline:
                 feature_set=self.feature_set,
                 spark_client=self.spark_client,
             )
+
+    def run_for_date(
+        self,
+        execution_date: str = None,
+        partition_by: List[str] = None,
+        order_by: List[str] = None,
+        num_processors: int = None,
+    ):
+        """Runs the defined feature set pipeline for a specific date.
+
+        The pipeline consists in the following steps:
+        - Constructs the input dataframe from the data source.
+        - Construct the feature set dataframe using the defined Features.
+        - Load the data to the configured sink locations.
+
+        It's important to notice, however, that both parameters partition_by
+        and num_processors are WIP, we intend to enhance their functionality
+        soon. Use only if strictly necessary.
+
+        """
+        start_date = execution_date
+
+        end_date = (
+            datetime.strptime(execution_date, "%Y-%m-%d") + timedelta(days=1)
+        ).strftime("%Y-%m-%d")
+
+        self.run(
+            start_date=start_date,
+            end_date=end_date,
+            partition_by=partition_by,
+            order_by=order_by,
+            num_processors=num_processors,
+        )

--- a/butterfree/pipelines/feature_set_pipeline.py
+++ b/butterfree/pipelines/feature_set_pipeline.py
@@ -1,5 +1,4 @@
 """FeatureSetPipeline entity."""
-from datetime import datetime, timedelta
 from typing import List
 
 from butterfree.clients import SparkClient
@@ -245,15 +244,9 @@ class FeatureSetPipeline:
         soon. Use only if strictly necessary.
 
         """
-        start_date = execution_date
-
-        end_date = (
-            datetime.strptime(execution_date, "%Y-%m-%d") + timedelta(days=1)
-        ).strftime("%Y-%m-%d")
-
         self.run(
-            start_date=start_date,
-            end_date=end_date,
+            start_date=execution_date,
+            end_date=execution_date,
             partition_by=partition_by,
             order_by=order_by,
             num_processors=num_processors,

--- a/tests/integration/butterfree/pipelines/conftest.py
+++ b/tests/integration/butterfree/pipelines/conftest.py
@@ -113,6 +113,15 @@ def fixed_windows_output_feature_set_date_dataframe(spark_context, spark_session
             "month": 4,
             "day": 12,
         },
+        {
+            "id": 1,
+            "timestamp": "2016-04-13 11:46:24",
+            "feature__avg_over_1_day_fixed_windows": 400,
+            "feature__stddev_pop_over_1_day_fixed_windows": 0,
+            "year": 2016,
+            "month": 4,
+            "day": 13,
+        },
     ]
     df = spark_session.read.json(spark_context.parallelize(data, 1))
     df = df.withColumn(TIMESTAMP_COLUMN, df.timestamp.cast(DataType.TIMESTAMP.spark))

--- a/tests/integration/butterfree/pipelines/conftest.py
+++ b/tests/integration/butterfree/pipelines/conftest.py
@@ -74,3 +74,36 @@ def fixed_windows_output_feature_set_dataframe(spark_context, spark_session):
     df = df.withColumn(TIMESTAMP_COLUMN, df.timestamp.cast(DataType.TIMESTAMP.spark))
 
     return df
+
+
+@pytest.fixture()
+def mocked_date_df(spark_context, spark_session):
+    data = [
+        {"id": 1, "ts": "2016-04-11 11:31:11", "feature": 200},
+        {"id": 1, "ts": "2016-04-12 11:44:12", "feature": 300},
+        {"id": 1, "ts": "2016-04-13 11:46:24", "feature": 400},
+        {"id": 1, "ts": "2016-04-14 12:03:21", "feature": 500},
+    ]
+    df = spark_session.read.json(spark_context.parallelize(data, 1))
+    df = df.withColumn(TIMESTAMP_COLUMN, df.ts.cast(DataType.TIMESTAMP.spark))
+
+    return df
+
+
+@pytest.fixture()
+def fixed_windows_output_feature_set_date_dataframe(spark_context, spark_session):
+    data = [
+        {
+            "id": 1,
+            "timestamp": "2016-04-12 11:44:12",
+            "feature__avg_over_1_day_fixed_windows": 300,
+            "feature__stddev_pop_over_1_day_fixed_windows": 0,
+            "year": 2016,
+            "month": 4,
+            "day": 12,
+        },
+    ]
+    df = spark_session.read.json(spark_context.parallelize(data, 1))
+    df = df.withColumn(TIMESTAMP_COLUMN, df.timestamp.cast(DataType.TIMESTAMP.spark))
+
+    return df

--- a/tests/integration/butterfree/pipelines/conftest.py
+++ b/tests/integration/butterfree/pipelines/conftest.py
@@ -1,7 +1,18 @@
 import pytest
+from pyspark.sql import functions as F
 
 from butterfree.constants import DataType
 from butterfree.constants.columns import TIMESTAMP_COLUMN
+from butterfree.dataframe_service.incremental_strategy import IncrementalStrategy
+from butterfree.extract import Source
+from butterfree.extract.readers import TableReader
+from butterfree.load import Sink
+from butterfree.load.writers import HistoricalFeatureStoreWriter
+from butterfree.pipelines.feature_set_pipeline import FeatureSetPipeline
+from butterfree.transform import FeatureSet
+from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
+from butterfree.transform.transformations import SparkFunctionTransform
+from butterfree.transform.utils import Function
 
 
 @pytest.fixture()
@@ -107,3 +118,50 @@ def fixed_windows_output_feature_set_date_dataframe(spark_context, spark_session
     df = df.withColumn(TIMESTAMP_COLUMN, df.timestamp.cast(DataType.TIMESTAMP.spark))
 
     return df
+
+
+@pytest.fixture()
+def feature_set_pipeline(spark_context, spark_session):
+    feature_set_pipeline = FeatureSetPipeline(
+        source=Source(
+            readers=[
+                TableReader(id="b_source", table="b_table",).with_incremental_strategy(
+                    incremental_strategy=IncrementalStrategy(column="timestamp")
+                ),
+            ],
+            query=f"select * from b_source ",  # noqa
+        ),
+        feature_set=FeatureSet(
+            name="feature_set",
+            entity="entity",
+            description="description",
+            features=[
+                Feature(
+                    name="feature",
+                    description="test",
+                    transformation=SparkFunctionTransform(
+                        functions=[
+                            Function(F.avg, DataType.FLOAT),
+                            Function(F.stddev_pop, DataType.FLOAT),
+                        ],
+                    ).with_window(
+                        partition_by="id",
+                        order_by=TIMESTAMP_COLUMN,
+                        mode="fixed_windows",
+                        window_definition=["1 day"],
+                    ),
+                ),
+            ],
+            keys=[
+                KeyFeature(
+                    name="id",
+                    description="The user's Main ID or device ID",
+                    dtype=DataType.INTEGER,
+                )
+            ],
+            timestamp=TimestampFeature(),
+        ),
+        sink=Sink(writers=[HistoricalFeatureStoreWriter(debug_mode=True)]),
+    )
+
+    return feature_set_pipeline

--- a/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
+++ b/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
@@ -164,6 +164,9 @@ class TestFeatureSetPipeline:
         feature_set_pipeline.run_for_date(execution_date="2016-04-12")
 
         df = spark_session.sql("select * from historical_feature_store__feature_set")
+        target_df = fixed_windows_output_feature_set_date_dataframe.filter(
+            "timestamp < '2016-04-13'"
+        )
 
         # assert
-        assert_dataframe_equality(df, fixed_windows_output_feature_set_date_dataframe)
+        assert_dataframe_equality(df, target_df)

--- a/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
+++ b/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
@@ -138,8 +138,8 @@ class TestFeatureSetPipeline:
         fixed_windows_output_feature_set_date_dataframe,
     ):
         # arrange
-        table_reader_id = "a_source"
-        table_reader_table = "table"
+        table_reader_id = "b_source"
+        table_reader_table = "b_table"
         table_reader_db = environment.get_variable("FEATURE_STORE_HISTORICAL_DATABASE")
         create_temp_view(dataframe=mocked_date_df, name=table_reader_id)
         create_db_and_table(
@@ -226,8 +226,8 @@ class TestFeatureSetPipeline:
         fixed_windows_output_feature_set_date_dataframe,
     ):
         # arrange
-        table_reader_id = "a_source"
-        table_reader_table = "table"
+        table_reader_id = "b_source"
+        table_reader_table = "b_table"
         table_reader_db = environment.get_variable("FEATURE_STORE_HISTORICAL_DATABASE")
         create_temp_view(dataframe=mocked_date_df, name=table_reader_id)
         create_db_and_table(

--- a/tests/unit/butterfree/dataframe_service/test_incremental_strategy.py
+++ b/tests/unit/butterfree/dataframe_service/test_incremental_strategy.py
@@ -18,7 +18,7 @@ class TestIncrementalStrategy:
         incremental_strategy = IncrementalStrategy().from_string(
             "dt", mask="dd/MM/yyyy"
         )
-        target_expression = "to_date(dt, 'dd/MM/yyyy') >= date('2020-01-01')"
+        target_expression = "date(to_date(dt, 'dd/MM/yyyy')) >= date('2020-01-01')"
 
         # act
         result_expression = incremental_strategy.get_expression(start_date="2020-01-01")
@@ -46,7 +46,7 @@ class TestIncrementalStrategy:
     def test_get_expression_with_just_end_date(self):
         # arrange
         incremental_strategy = IncrementalStrategy(column="dt")
-        target_expression = "dt <= date('2020-01-01')"
+        target_expression = "date(dt) <= date('2020-01-01')"
 
         # act
         result_expression = incremental_strategy.get_expression(end_date="2020-01-01")
@@ -57,7 +57,9 @@ class TestIncrementalStrategy:
     def test_get_expression_with_start_and_end_date(self):
         # arrange
         incremental_strategy = IncrementalStrategy(column="dt")
-        target_expression = "dt >= date('2019-12-30') and dt <= date('2020-01-01')"
+        target_expression = (
+            "date(dt) >= date('2019-12-30') and date(dt) <= date('2020-01-01')"
+        )
 
         # act
         result_expression = incremental_strategy.get_expression(


### PR DESCRIPTION
## Why? :open_book:
It was necessary to deal with the ```execution_date``` parameter.

## What? :wrench:
Added a new method within ```FeatureSetPipeline``` class.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Integration tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

