### PR TITLE
Fix broken notebook URL

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,6 @@ Welcome to **Discovering Butterfree** tutorial series! Click on the following li
 
 **[#2 Spark Functions and Window](https://github.com/quintoandar/butterfree/blob/master/examples/spark_function_and_window/spark_function_and_window.ipynb)**
 
-**[#3 Aggregated Feature Set](https://github.com/quintoandar/butterfree/blob/master/examples/aggregated_feature_set/aggregated_feature_set%20.ipynb)**
+**[#3 Aggregated Feature Set](https://github.com/quintoandar/butterfree/blob/master/examples/aggregated_feature_set/aggregated_feature_set.ipynb)**
 
 **[#4 Streaming Feature Set](https://github.com/quintoandar/butterfree/blob/master/examples/streaming_feature_set/streaming_feature_set.ipynb)**


### PR DESCRIPTION
## Why? :open_book:
This PR is created to fix the third notebook's broken URL in the examples README.

## What? :wrench:
This PR modifies the examples README in order to remove an unnecessary space character in the third notebook's URL.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How everything was tested? :straight_ruler:
Tested the third notebook's URL after modifying the README: it points to the correct notebook.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
None.