### PR TITLE
[MLOP-459] Create HookableComponent

### DIFF
--- a/butterfree/hooks/__init__.py
+++ b/butterfree/hooks/__init__.py
@@ -1,1 +1,5 @@
 """Holds Hooks definitions."""
+from butterfree.hooks.hook import Hook
+from butterfree.hooks.hookable_component import HookableComponent
+
+__all__ = ["Hook", "HookableComponent"]

--- a/butterfree/hooks/hookable_component.py
+++ b/butterfree/hooks/hookable_component.py
@@ -1,0 +1,154 @@
+"""Definition of hookable component."""
+
+from __future__ import annotations
+
+from functools import reduce
+from typing import List
+
+from pyspark.sql import DataFrame
+
+from butterfree.hooks.hook import Hook
+
+
+class HookableComponent:
+    """Defines a component with the ability to hold pre and post hook functions.
+
+    All main module of Butterfree have a common object that enables their integration:
+    dataframes. Spark's dataframe is the glue that enables the transmission of data
+    between the main modules. Hooks have a simple interface, they are functions that
+    accepts a dataframe and outputs a dataframe. These Hooks can be triggered before or
+    after the main execution of a component.
+
+    Components from Butterfree that inherit HookableComponent entity, are components
+    that can define a series of steps to occur before or after the execution of their
+    main functionality.
+
+    Attributes:
+        pre_hooks: function steps to trigger before component main functionality.
+        post_hooks: function steps to trigger after component main functionality.
+        enable_pre_hooks: property to indicate if the component can define pre_hooks.
+        enable_post_hooks: property to indicate if the component can define post_hooks.
+
+    """
+
+    def __init__(self):
+        self.pre_hooks = []
+        self.post_hooks = []
+        self.enable_pre_hooks = True
+        self.enable_post_hooks = True
+
+    @property
+    def pre_hooks(self) -> List[Hook]:
+        """Function steps to trigger before component main functionality."""
+        return self.__pre_hook
+
+    @pre_hooks.setter
+    def pre_hooks(self, value: List[Hook]) -> None:
+        if not isinstance(value, list):
+            raise ValueError("pre_hooks should be a list of Hooks.")
+        if not all(isinstance(item, Hook) for item in value):
+            raise ValueError(
+                "All items on pre_hooks list should be an instance of Hook."
+            )
+        self.__pre_hook = value
+
+    @property
+    def post_hooks(self) -> List[Hook]:
+        """Function steps to trigger after component main functionality."""
+        return self.__post_hook
+
+    @post_hooks.setter
+    def post_hooks(self, value: List[Hook]) -> None:
+        if not isinstance(value, list):
+            raise ValueError("post_hooks should be a list of Hooks.")
+        if not all(isinstance(item, Hook) for item in value):
+            raise ValueError(
+                "All items on post_hooks list should be an instance of Hook."
+            )
+        self.__post_hook = value
+
+    @property
+    def enable_pre_hooks(self) -> bool:
+        """Property to indicate if the component can define pre_hooks."""
+        return self.__enable_pre_hooks
+
+    @enable_pre_hooks.setter
+    def enable_pre_hooks(self, value: List[Hook]) -> None:
+        if not isinstance(value, bool):
+            raise ValueError("enable_pre_hooks accepts only boolean values.")
+        self.__enable_pre_hooks = value
+
+    @property
+    def enable_post_hooks(self) -> bool:
+        """Property to indicate if the component can define post_hooks."""
+        return self.__enable_post_hooks
+
+    @enable_post_hooks.setter
+    def enable_post_hooks(self, value: List[Hook]) -> None:
+        if not isinstance(value, bool):
+            raise ValueError("enable_post_hooks accepts only boolean values.")
+        self.__enable_post_hooks = value
+
+    def add_pre_hook(self, *hooks: Hook) -> HookableComponent:
+        """Add a pre-hook steps to the component.
+
+        Args:
+            hooks: Hook steps to add to pre_hook list.
+
+        Returns:
+            Component with the Hook inserted in pre_hook list.
+
+        Raises:
+            ValueError: if the component does not accept pre-hooks.
+
+        """
+        if not self.enable_pre_hooks:
+            raise ValueError("This component does not enable adding pre-hooks")
+        self.pre_hooks += list(hooks)
+        return self
+
+    def add_post_hook(self, *hooks: Hook) -> HookableComponent:
+        """Add a post-hook steps to the component.
+
+        Args:
+            hooks: Hook steps to add to post_hook list.
+
+        Returns:
+            Component with the Hook inserted in post_hook list.
+
+        Raises:
+            ValueError: if the component does not accept post-hooks.
+
+        """
+        if not self.enable_post_hooks:
+            raise ValueError("This component does not enable adding post-hooks")
+        self.post_hooks += list(hooks)
+        return self
+
+    def run_pre_hooks(self, dataframe: DataFrame) -> DataFrame:
+        """Run all defined pre-hook steps from a given dataframe.
+
+        Args:
+            dataframe: data to input in the defined pre-hook steps.
+
+        Returns:
+            dataframe after passing for all defined pre-hooks.
+
+        """
+        return reduce(
+            lambda result_df, hook: hook.run(result_df), self.pre_hooks, dataframe,
+        )
+
+    def run_post_hooks(self, dataframe: DataFrame) -> DataFrame:
+        """Run all defined post-hook steps from a given dataframe.
+
+        Args:
+            dataframe: data to input in the defined post-hook steps.
+
+        Returns:
+            dataframe after passing for all defined post-hooks.
+
+        """
+        return reduce(
+            lambda result_df, hook: hook.run(result_df), self.post_hooks, dataframe,
+        )

--- a/butterfree/hooks/hookable_component.py
+++ b/butterfree/hooks/hookable_component.py
@@ -135,9 +135,9 @@ class HookableComponent:
             dataframe after passing for all defined pre-hooks.
 
         """
-        return reduce(
-            lambda result_df, hook: hook.run(result_df), self.pre_hooks, dataframe,
-        )
+        for hook in self.pre_hooks:
+            dataframe = hook.run(dataframe)
+        return dataframe
 
     def run_post_hooks(self, dataframe: DataFrame) -> DataFrame:
         """Run all defined post-hook steps from a given dataframe.
@@ -149,6 +149,6 @@ class HookableComponent:
             dataframe after passing for all defined post-hooks.
 
         """
-        return reduce(
-            lambda result_df, hook: hook.run(result_df), self.post_hooks, dataframe,
-        )
+        for hook in self.pre_hooks:
+            dataframe = hook.run(dataframe)
+        return dataframe

--- a/butterfree/hooks/hookable_component.py
+++ b/butterfree/hooks/hookable_component.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from functools import reduce
 from typing import List
 
 from pyspark.sql import DataFrame

--- a/tests/unit/butterfree/hooks/test_hookable_component.py
+++ b/tests/unit/butterfree/hooks/test_hookable_component.py
@@ -51,6 +51,24 @@ class TestHookableComponent:
             hookable_component.enable_post_hooks = enable_post_hooks
 
     @pytest.mark.parametrize(
+        "pre_hooks, post_hooks",
+        [
+            ([AddHook(1)], "not a list of hooks"),
+            ([AddHook(1)], [AddHook(1), 2, 3]),
+            ("not a list of hooks", [AddHook(1)]),
+            ([AddHook(1), 2, 3], [AddHook(1)]),
+        ],
+    )
+    def test_invalid_hooks(self, pre_hooks, post_hooks):
+        # arrange
+        hookable_component = HookableComponent()
+
+        # act and assert
+        with pytest.raises(ValueError):
+            hookable_component.pre_hooks = pre_hooks
+            hookable_component.post_hooks = post_hooks
+
+    @pytest.mark.parametrize(
         "pre_hook, enable_pre_hooks, post_hook, enable_post_hooks",
         [
             (AddHook(value=1), False, AddHook(value=1), True),

--- a/tests/unit/butterfree/hooks/test_hookable_component.py
+++ b/tests/unit/butterfree/hooks/test_hookable_component.py
@@ -1,0 +1,89 @@
+import pytest
+from pyspark.sql.functions import expr
+
+from butterfree.hooks import Hook, HookableComponent
+from butterfree.testing.dataframe import assert_dataframe_equality
+
+
+class TestComponent(HookableComponent):
+    def construct(self, dataframe):
+        pre_hook_df = self.run_pre_hooks(dataframe)
+        construc_df = pre_hook_df.withColumn("feature", expr("feature * feature"))
+        return self.run_post_hooks(construc_df)
+
+
+class AddHook(Hook):
+    def __init__(self, value):
+        self.value = value
+
+    def run(self, dataframe):
+        return dataframe.withColumn("feature", expr(f"feature + {self.value}"))
+
+
+class TestHookableComponent:
+    def test_add_hooks(self):
+        # arrange
+        hook1 = AddHook(value=1)
+        hook2 = AddHook(value=2)
+        hook3 = AddHook(value=3)
+        hook4 = AddHook(value=4)
+        hookable_component = HookableComponent()
+
+        # act
+        hookable_component.add_pre_hook(hook1, hook2)
+        hookable_component.add_post_hook(hook3, hook4)
+
+        # assert
+        assert hookable_component.pre_hooks == [hook1, hook2]
+        assert hookable_component.post_hooks == [hook3, hook4]
+
+    @pytest.mark.parametrize(
+        "enable_pre_hooks, enable_post_hooks",
+        [("not boolean", False), (False, "not boolean")],
+    )
+    def test_invalid_enable_hook(self, enable_pre_hooks, enable_post_hooks):
+        # arrange
+        hookable_component = HookableComponent()
+
+        # act and assert
+        with pytest.raises(ValueError):
+            hookable_component.enable_pre_hooks = enable_pre_hooks
+            hookable_component.enable_post_hooks = enable_post_hooks
+
+    @pytest.mark.parametrize(
+        "pre_hook, enable_pre_hooks, post_hook, enable_post_hooks",
+        [
+            (AddHook(value=1), False, AddHook(value=1), True),
+            (AddHook(value=1), True, AddHook(value=1), False),
+            ("not a pre-hook", True, AddHook(value=1), True),
+            (AddHook(value=1), True, "not a pre-hook", True),
+        ],
+    )
+    def test_add_invalid_hooks(
+        self, pre_hook, enable_pre_hooks, post_hook, enable_post_hooks
+    ):
+        # arrange
+        hookable_component = HookableComponent()
+        hookable_component.enable_pre_hooks = enable_pre_hooks
+        hookable_component.enable_post_hooks = enable_post_hooks
+
+        # act and assert
+        with pytest.raises(ValueError):
+            hookable_component.add_pre_hook(pre_hook)
+            hookable_component.add_post_hook(post_hook)
+
+    def test_run_hooks(self, spark_session):
+        # arrange
+        input_dataframe = spark_session.sql("select 2 as feature")
+        test_component = (
+            TestComponent()
+            .add_pre_hook(AddHook(value=1))
+            .add_post_hook(AddHook(value=1))
+        )
+        target_table = spark_session.sql("select 10 as feature")
+
+        # act
+        output_df = test_component.construct(input_dataframe)
+
+        # assert
+        assert_dataframe_equality(output_df, target_table)

--- a/tests/unit/butterfree/hooks/test_hookable_component.py
+++ b/tests/unit/butterfree/hooks/test_hookable_component.py
@@ -8,8 +8,8 @@ from butterfree.testing.dataframe import assert_dataframe_equality
 class TestComponent(HookableComponent):
     def construct(self, dataframe):
         pre_hook_df = self.run_pre_hooks(dataframe)
-        construc_df = pre_hook_df.withColumn("feature", expr("feature * feature"))
-        return self.run_post_hooks(construc_df)
+        construct_df = pre_hook_df.withColumn("feature", expr("feature * feature"))
+        return self.run_post_hooks(construct_df)
 
 
 class AddHook(Hook):


### PR DESCRIPTION
## Why? :open_book:
We need an entity defining with methods to add pre_hook and post_hook functions. Our main modules that will be able to use Hook will just need to inherit from this entity.

## What? :wrench:
- New `HookableComponent` entity

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
locally with tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

