### PR TITLE
[MLOP-454] Create Cassandra Check Hook

### DIFF
--- a/butterfree/hooks/schema_compatibility/__init__.py
+++ b/butterfree/hooks/schema_compatibility/__init__.py
@@ -1,4 +1,5 @@
-from butterfree.hooks.schema_compatibility.cassandra_table_schema_compatibility_hook import (
+"""Holds Schema Compatibility Hooks definitions."""
+from butterfree.hooks.schema_compatibility.cassandra_table_schema_compatibility_hook import (  # noqa
     CassandraTableSchemaCompatibilityHook,
 )
 from butterfree.hooks.schema_compatibility.spark_table_schema_compatibility_hook import (  # noqa

--- a/butterfree/hooks/schema_compatibility/__init__.py
+++ b/butterfree/hooks/schema_compatibility/__init__.py
@@ -1,5 +1,8 @@
+from butterfree.hooks.schema_compatibility.cassandra_table_schema_compatibility_hook import (
+    CassandraTableSchemaCompatibilityHook,
+)
 from butterfree.hooks.schema_compatibility.spark_table_schema_compatibility_hook import (  # noqa
     SparkTableSchemaCompatibilityHook,
 )
 
-__all__ = ["SparkTableSchemaCompatibilityHook"]
+__all__ = ["SparkTableSchemaCompatibilityHook", "CassandraTableSchemaCompatibilityHook"]

--- a/butterfree/hooks/schema_compatibility/cassandra_table_schema_compatibility_hook.py
+++ b/butterfree/hooks/schema_compatibility/cassandra_table_schema_compatibility_hook.py
@@ -1,0 +1,59 @@
+"""Spark table schema compatibility Hook definition."""
+
+from pyspark.sql import DataFrame
+
+from butterfree.clients import CassandraClient
+from butterfree.constants import DataType
+from butterfree.hooks.hook import Hook
+
+
+class CassandraTableSchemaCompatibilityHook(Hook):
+    """Hook to verify the schema compatibility with a Cassandra's table.
+
+    Verifies if all columns presented on the dataframe exists and are the same
+    type on the target Cassandra's table.
+
+    Attributes:
+        cassandra_client: client to connect to Cassandra DB.
+        table: table name.
+
+    """
+
+    def __init__(self, cassandra_client: CassandraClient, table: str):
+        self.cassandra_client = cassandra_client
+        self.table = table
+
+    def run(self, dataframe: DataFrame) -> DataFrame:
+        """Check the schema compatibility from a given Dataframe.
+
+        This method does not change anything on the Dataframe.
+
+        Args:
+            dataframe: dataframe to verify schema compatibility.
+
+        Returns:
+            unchanged dataframe.
+
+        Raises:
+            ValueError if the schemas are incompatible.
+
+        """
+        table_schema = self.cassandra_client.get_schema(self.table)
+        type_cassandra = [
+            type.cassandra
+            for field_id in range(len(dataframe.schema.fieldNames()))
+            for type in DataType
+            if dataframe.schema.fields.__getitem__(field_id).dataType == type.spark
+        ]
+        schema = [
+            {"column_name": f"{column}", "type": f"{type}"}
+            for column, type in zip(dataframe.columns, type_cassandra)
+        ]
+
+        if not all([column in table_schema for column in schema]):
+            raise ValueError(
+                "The dataframe has a schema incompatible with the defined table.\n"
+                f"Dataframe schema = {schema}"
+                f"Target table schema = {table_schema}"
+            )
+        return dataframe

--- a/butterfree/hooks/schema_compatibility/cassandra_table_schema_compatibility_hook.py
+++ b/butterfree/hooks/schema_compatibility/cassandra_table_schema_compatibility_hook.py
@@ -52,7 +52,8 @@ class CassandraTableSchemaCompatibilityHook(Hook):
 
         if not all([column in table_schema for column in schema]):
             raise ValueError(
-                "There's a schema incompatibility between the defined dataframe and the Cassandra table.\n"
+                "There's a schema incompatibility "
+                "between the defined dataframe and the Cassandra table.\n"
                 f"Dataframe schema = {schema}"
                 f"Target table schema = {table_schema}"
             )

--- a/butterfree/hooks/schema_compatibility/cassandra_table_schema_compatibility_hook.py
+++ b/butterfree/hooks/schema_compatibility/cassandra_table_schema_compatibility_hook.py
@@ -1,4 +1,4 @@
-"""Spark table schema compatibility Hook definition."""
+"""Cassandra table schema compatibility Hook definition."""
 
 from pyspark.sql import DataFrame
 
@@ -52,7 +52,7 @@ class CassandraTableSchemaCompatibilityHook(Hook):
 
         if not all([column in table_schema for column in schema]):
             raise ValueError(
-                "The dataframe has a schema incompatible with the defined table.\n"
+                "There's a schema incompatibility between the defined dataframe and the Cassandra table.\n"
                 f"Dataframe schema = {schema}"
                 f"Target table schema = {table_schema}"
             )

--- a/tests/unit/butterfree/hooks/schema_compatibility/test_cassandra_table_schema_compatibility_hook.py
+++ b/tests/unit/butterfree/hooks/schema_compatibility/test_cassandra_table_schema_compatibility_hook.py
@@ -47,5 +47,7 @@ class TestCassandraTableSchemaCompatibilityHook:
         hook = CassandraTableSchemaCompatibilityHook(cassandra_client, table)
 
         # act and assert
-        with pytest.raises(ValueError, match="There's a schema incompatibility between"):
+        with pytest.raises(
+            ValueError, match="There's a schema incompatibility between"
+        ):
             hook.run(input_dataframe)

--- a/tests/unit/butterfree/hooks/schema_compatibility/test_cassandra_table_schema_compatibility_hook.py
+++ b/tests/unit/butterfree/hooks/schema_compatibility/test_cassandra_table_schema_compatibility_hook.py
@@ -47,5 +47,5 @@ class TestCassandraTableSchemaCompatibilityHook:
         hook = CassandraTableSchemaCompatibilityHook(cassandra_client, table)
 
         # act and assert
-        with pytest.raises(ValueError, match="The dataframe has a schema incompatible"):
+        with pytest.raises(ValueError, match="There's a schema incompatibility between"):
             hook.run(input_dataframe)

--- a/tests/unit/butterfree/hooks/schema_compatibility/test_cassandra_table_schema_compatibility_hook.py
+++ b/tests/unit/butterfree/hooks/schema_compatibility/test_cassandra_table_schema_compatibility_hook.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from butterfree.clients import CassandraClient
+from butterfree.hooks.schema_compatibility import CassandraTableSchemaCompatibilityHook
+
+
+class TestCassandraTableSchemaCompatibilityHook:
+    def test_run_compatible_schema(self, spark_session):
+        cassandra_client = CassandraClient(
+            cassandra_host=["mock"], cassandra_key_space="dummy_keyspace"
+        )
+
+        cassandra_client.sql = MagicMock(  # type: ignore
+            return_value=[
+                {"column_name": "feature1", "type": "text"},
+                {"column_name": "feature2", "type": "int"},
+            ]
+        )
+
+        table = "table"
+
+        input_dataframe = spark_session.sql("select 'abc' as feature1, 1 as feature2")
+
+        hook = CassandraTableSchemaCompatibilityHook(cassandra_client, table)
+
+        # act and assert
+        assert hook.run(input_dataframe) == input_dataframe
+
+    def test_run_incompatible_schema(self, spark_session):
+        cassandra_client = CassandraClient(
+            cassandra_host=["mock"], cassandra_key_space="dummy_keyspace"
+        )
+
+        cassandra_client.sql = MagicMock(  # type: ignore
+            return_value=[
+                {"column_name": "feature1", "type": "text"},
+                {"column_name": "feature2", "type": "bigint"},
+            ]
+        )
+
+        table = "table"
+
+        input_dataframe = spark_session.sql("select 'abc' as feature1, 1 as feature2")
+
+        hook = CassandraTableSchemaCompatibilityHook(cassandra_client, table)
+
+        # act and assert
+        with pytest.raises(ValueError, match="The dataframe has a schema incompatible"):
+            hook.run(input_dataframe)


### PR DESCRIPTION
## Why? :open_book:
We want to separate some responsibilities from the main ETL modules (Source, Feature Set, and Sink), so we will create hooks containing these logics.

In this approach, this task is summarized in the creation of a hook where we will have a schema check of the feature sets that will use CassandraClient. This hook will be a pre-writer.

## What? :wrench:
- CassandraTableSchemaCompatibilityHook :star2: 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
- Unit Tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.