### PR TITLE
[MLOP-463] Remove transformations from Source and Feature Set

### DIFF
--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -75,7 +75,4 @@ class Source:
 
         dataframe = client.sql(self.query)
 
-        if not dataframe.isStreaming:
-            dataframe.cache().count()
-
         return dataframe

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -539,6 +539,5 @@ class AggregatedFeatureSet(FeatureSet):
         output_df = output_df.select(*self.columns).replace(float("nan"), None)
         if not output_df.isStreaming:
             output_df = self._filter_duplicated_rows(output_df)
-            output_df.cache().count()
 
         return output_df

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -411,6 +411,5 @@ class FeatureSet:
 
         if not output_df.isStreaming:
             output_df = self._filter_duplicated_rows(output_df)
-            output_df.cache().count()
 
         return output_df

--- a/tests/unit/butterfree/extract/test_source.py
+++ b/tests/unit/butterfree/extract/test_source.py
@@ -20,21 +20,3 @@ class TestSource:
         result_df = source_selector.construct(spark_client)
 
         assert result_df.collect() == target_df.collect()
-
-    def test_is_cached(self, mocker, target_df):
-        # given
-        spark_client = SparkClient()
-
-        reader_id = "a_source"
-        reader = mocker.stub(reader_id)
-        reader.build = mocker.stub("build")
-        reader.build.side_effect = target_df.createOrReplaceTempView(reader_id)
-
-        # when
-        source_selector = Source(
-            readers=[reader], query=f"select * from {reader_id}",  # noqa
-        )
-
-        result_df = source_selector.construct(spark_client)
-
-        assert result_df.is_cached

--- a/tests/unit/butterfree/transform/test_feature_set.py
+++ b/tests/unit/butterfree/transform/test_feature_set.py
@@ -215,7 +215,6 @@ class TestFeatureSet:
             + feature_divide.get_output_columns()
         )
         assert_dataframe_equality(result_df, feature_set_dataframe)
-        assert result_df.is_cached
 
     def test_construct_invalid_df(
         self, key_id, timestamp_c, feature_add, feature_divide


### PR DESCRIPTION
## Why? :open_book:
Lazy evaluation in Spark means that the execution will not start until an action, such as count or cache, is triggered. We want to remove them since we’ll have a pre-hook in Writer to check schemas.

## What? :wrench:
- Source
- Feature Set
- Aggregated Feature Set

## Type of change
- [x] New feature (non-breaking change which adds functionality)


## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
