### PR TITLE
[MLOP-472] Enable dynamic partition on incremental mode

### DIFF
--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -177,11 +177,17 @@ class HistoricalFeatureStoreWriter(Writer):
 
         """
         table_name = (
-            f"{self.database}.{feature_set.name}"
+            f"{feature_set.name}"
             if not self.debug_mode
             else f"historical_feature_store__{feature_set.name}"
         )
-        written_count = spark_client.read_table(table_name).count()
+        written_count = (
+            spark_client.read(
+                self.db_config.format_, options=self.db_config.get_options(table_name)
+            ).count()
+            if not self.debug_mode
+            else spark_client.read_table(table_name).count()
+        )
         dataframe_count = dataframe.count()
         self._assert_validation_count(table_name, written_count, dataframe_count)
 

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -141,9 +141,13 @@ class HistoricalFeatureStoreWriter(Writer):
             **self.db_config.get_options(s3_key),
         )
 
-    def _incremental_mode(self, feature_set: FeatureSet, dataframe: DataFrame, spark_client: SparkClient):
+    def _incremental_mode(
+        self, feature_set: FeatureSet, dataframe: DataFrame, spark_client: SparkClient
+    ):
 
-        spark_client.conn.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
+        spark_client.conn.conf.set(
+            "spark.sql.sources.partitionOverwriteMode", "dynamic"
+        )
 
         partition_overwrite_mode = spark_client.conn.conf.get(
             "spark.sql.sources.partitionOverwriteMode"
@@ -151,23 +155,22 @@ class HistoricalFeatureStoreWriter(Writer):
 
         if partition_overwrite_mode != "dynamic":
             raise RuntimeError(
-                "m=load_incremental_table, spark.sql.sources.partitionOverwriteMode={}, "
-                "msg=partitionOverwriteMode have to be configured to 'dynamic'".format(
-                    partition_overwrite_mode
-                )
+                "m=load_incremental_table, "
+                "spark.sql.sources.partitionOverwriteMode={}, "
+                "msg=partitionOverwriteMode "
+                "have to be configured to 'dynamic'".format(partition_overwrite_mode)
             )
 
         s3_key = os.path.join("historical", feature_set.entity, feature_set.name)
-        options = {'path': self.db_config.get_options(s3_key).get("path")}
+        options = {"path": self.db_config.get_options(s3_key).get("path")}
 
         spark_client.write_dataframe(
             dataframe=dataframe,
             format_=self.db_config.format_,
             mode=self.db_config.mode,
             **options,
-            partitionBy=self.PARTITION_BY
+            partitionBy=self.PARTITION_BY,
         )
-
 
     def _assert_validation_count(self, table_name, written_count, dataframe_count):
         lower_bound = (1 - self.validation_threshold) * written_count

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -71,9 +71,16 @@ class HistoricalFeatureStoreWriter(Writer):
         Both methods (write and validate) will need the Spark Client, Feature Set
         and DataFrame, to write or to validate, according to the Writer's arguments.
 
-        P.S.: When writing, the HistoricalFeatureStoreWrite partitions the data to
+        P.S.(1): When writing, the HistoricalFeatureStoreWrite partitions the data to
         improve queries performance. The data is stored in partition folders in AWS S3
         based on time (per year, month and day).
+
+        P.S.(2): HistoricalFeatureStoreWrite use Dynamic Partition Inserts,
+        the behaviour of OVERWRITE keyword is controlled by
+        spark.sql.sources.partitionOverwriteMode configuration property.
+        The dynamic overwrite mode is enabled Spark will only delete the
+        partitions for which it has data to be written to.
+        All the other partitions remain intact.
 
     """
 
@@ -133,7 +140,7 @@ class HistoricalFeatureStoreWriter(Writer):
 
         if partition_overwrite_mode != "dynamic":
             raise RuntimeError(
-                "m=load_incremental_table, "
+                "m=load_incremental, "
                 "spark.sql.sources.partitionOverwriteMode={}, "
                 "msg=partitionOverwriteMode "
                 "have to be configured to 'dynamic'".format(partition_overwrite_mode)

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -127,10 +127,6 @@ class HistoricalFeatureStoreWriter(Writer):
             )
             return
 
-        if feature_set._start_date:
-            self._incremental_mode(feature_set, dataframe, spark_client)
-            return
-
         s3_key = os.path.join("historical", feature_set.entity, feature_set.name)
 
         spark_client.write_table(
@@ -139,37 +135,6 @@ class HistoricalFeatureStoreWriter(Writer):
             table_name=feature_set.name,
             partition_by=self.PARTITION_BY,
             **self.db_config.get_options(s3_key),
-        )
-
-    def _incremental_mode(
-        self, feature_set: FeatureSet, dataframe: DataFrame, spark_client: SparkClient
-    ):
-
-        spark_client.conn.conf.set(
-            "spark.sql.sources.partitionOverwriteMode", "dynamic"
-        )
-
-        partition_overwrite_mode = spark_client.conn.conf.get(
-            "spark.sql.sources.partitionOverwriteMode"
-        ).lower()
-
-        if partition_overwrite_mode != "dynamic":
-            raise RuntimeError(
-                "m=load_incremental_table, "
-                "spark.sql.sources.partitionOverwriteMode={}, "
-                "msg=partitionOverwriteMode "
-                "have to be configured to 'dynamic'".format(partition_overwrite_mode)
-            )
-
-        s3_key = os.path.join("historical", feature_set.entity, feature_set.name)
-        options = {"path": self.db_config.get_options(s3_key).get("path")}
-
-        spark_client.write_dataframe(
-            dataframe=dataframe,
-            format_=self.db_config.format_,
-            mode=self.db_config.mode,
-            **options,
-            partitionBy=self.PARTITION_BY,
         )
 
     def _assert_validation_count(self, table_name, written_count, dataframe_count):

--- a/tests/integration/butterfree/load/test_sink.py
+++ b/tests/integration/butterfree/load/test_sink.py
@@ -12,6 +12,7 @@ from butterfree.load.writers import (
 def test_sink(input_dataframe, feature_set):
     # arrange
     client = SparkClient()
+    client.conn.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
     feature_set_df = feature_set.construct(input_dataframe, client)
     target_latest_df = OnlineFeatureStoreWriter.filter_latest(
         feature_set_df, id_columns=[key.name for key in feature_set.keys]
@@ -20,12 +21,10 @@ def test_sink(input_dataframe, feature_set):
 
     # setup historical writer
     s3config = Mock()
+    s3config.mode = "overwrite"
+    s3config.format_ = "parquet"
     s3config.get_options = Mock(
-        return_value={
-            "mode": "overwrite",
-            "format_": "parquet",
-            "path": "test_folder/historical/entity/feature_set",
-        }
+        return_value={"path": "test_folder/historical/entity/feature_set"}
     )
     historical_writer = HistoricalFeatureStoreWriter(db_config=s3config)
 
@@ -47,8 +46,8 @@ def test_sink(input_dataframe, feature_set):
     sink.flush(feature_set, feature_set_df, client)
 
     # get historical results
-    historical_result_df = client.read_table(
-        feature_set.name, historical_writer.database
+    historical_result_df = client.read(
+        s3config.format_, options=s3config.get_options(feature_set.name)
     )
 
     # get online results

--- a/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
+++ b/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from pyspark.sql import DataFrame
 from pyspark.sql import functions as F
 
+from butterfree.clients import SparkClient
 from butterfree.configs import environment
 from butterfree.constants import DataType
 from butterfree.constants.columns import TIMESTAMP_COLUMN
@@ -53,13 +54,17 @@ class TestFeatureSetPipeline:
             table_reader_db=table_reader_db,
             table_reader_table=table_reader_table,
         )
+
+        spark_client = SparkClient()
+        spark_client.conn.conf.set(
+            "spark.sql.sources.partitionOverwriteMode", "dynamic"
+        )
+
         dbconfig = Mock()
+        dbconfig.mode = "overwrite"
+        dbconfig.format_ = "parquet"
         dbconfig.get_options = Mock(
-            return_value={
-                "mode": "overwrite",
-                "format_": "parquet",
-                "path": "test_folder/historical/entity/feature_set",
-            }
+            return_value={"path": "test_folder/historical/entity/feature_set"}
         )
 
         # act

--- a/tests/unit/butterfree/load/conftest.py
+++ b/tests/unit/butterfree/load/conftest.py
@@ -33,6 +33,31 @@ def feature_set():
 
 
 @fixture
+def feature_set_incremental():
+    key_features = [
+        KeyFeature(name="id", description="Description", dtype=DataType.INTEGER)
+    ]
+    ts_feature = TimestampFeature(from_column=TIMESTAMP_COLUMN)
+    features = [
+        Feature(
+            name="feature",
+            description="test",
+            transformation=AggregatedTransform(
+                functions=[Function(functions.sum, DataType.INTEGER)]
+            ),
+        ),
+    ]
+    return AggregatedFeatureSet(
+        "feature_set",
+        "entity",
+        "description",
+        keys=key_features,
+        timestamp=ts_feature,
+        features=features,
+    )
+
+
+@fixture
 def feature_set_dataframe(spark_context, spark_session):
     data = [
         {"id": 1, TIMESTAMP_COLUMN: "2019-12-31", "feature": 100},

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -189,3 +189,31 @@ class TestHistoricalFeatureStoreWriter:
         # act and assert
         with pytest.raises(AssertionError):
             writer._assert_validation_count("table", written_count, dataframe_count)
+
+    def test_write_in_incremental_mode(
+                    self,
+                    feature_set_dataframe,
+                    historical_feature_set_dataframe,
+                    feature_set_incremental,
+                    mocker,
+                    spark_session,
+            ):
+                # given
+                # spark_client = mocker.stub("spark_client")
+                # spark_client.conn = mocker.stub("conn")
+                # spark_client.conn.conf = mocker.stub("conf")
+                spark_client = SparkClient()
+                spark_client.write_dataframe = mocker.stub("write_dataframe")
+                writer = HistoricalFeatureStoreWriter()
+                feature_set_incremental._start_date = "2019-12-31"
+
+                # when
+                writer.write(
+                    feature_set=feature_set_incremental,
+                    dataframe=feature_set_dataframe,
+                    spark_client=spark_client,
+                )
+                result_df = spark_client.write_dataframe.call_args[1]["dataframe"]
+
+                # then
+                assert_dataframe_equality(historical_feature_set_dataframe, result_df)

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -191,29 +191,29 @@ class TestHistoricalFeatureStoreWriter:
             writer._assert_validation_count("table", written_count, dataframe_count)
 
     def test_write_in_incremental_mode(
-                    self,
-                    feature_set_dataframe,
-                    historical_feature_set_dataframe,
-                    feature_set_incremental,
-                    mocker,
-                    spark_session,
-            ):
-                # given
-                # spark_client = mocker.stub("spark_client")
-                # spark_client.conn = mocker.stub("conn")
-                # spark_client.conn.conf = mocker.stub("conf")
-                spark_client = SparkClient()
-                spark_client.write_dataframe = mocker.stub("write_dataframe")
-                writer = HistoricalFeatureStoreWriter()
-                feature_set_incremental._start_date = "2019-12-31"
+        self,
+        feature_set_dataframe,
+        historical_feature_set_dataframe,
+        feature_set_incremental,
+        mocker,
+        spark_session,
+    ):
+        # given
+        # spark_client = mocker.stub("spark_client")
+        # spark_client.conn = mocker.stub("conn")
+        # spark_client.conn.conf = mocker.stub("conf")
+        spark_client = SparkClient()
+        spark_client.write_dataframe = mocker.stub("write_dataframe")
+        writer = HistoricalFeatureStoreWriter()
+        feature_set_incremental._start_date = "2019-12-31"
 
-                # when
-                writer.write(
-                    feature_set=feature_set_incremental,
-                    dataframe=feature_set_dataframe,
-                    spark_client=spark_client,
-                )
-                result_df = spark_client.write_dataframe.call_args[1]["dataframe"]
+        # when
+        writer.write(
+            feature_set=feature_set_incremental,
+            dataframe=feature_set_dataframe,
+            spark_client=spark_client,
+        )
+        result_df = spark_client.write_dataframe.call_args[1]["dataframe"]
 
-                # then
-                assert_dataframe_equality(historical_feature_set_dataframe, result_df)
+        # then
+        assert_dataframe_equality(historical_feature_set_dataframe, result_df)

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -189,31 +189,3 @@ class TestHistoricalFeatureStoreWriter:
         # act and assert
         with pytest.raises(AssertionError):
             writer._assert_validation_count("table", written_count, dataframe_count)
-
-    def test_write_in_incremental_mode(
-        self,
-        feature_set_dataframe,
-        historical_feature_set_dataframe,
-        feature_set_incremental,
-        mocker,
-        spark_session,
-    ):
-        # given
-        # spark_client = mocker.stub("spark_client")
-        # spark_client.conn = mocker.stub("conn")
-        # spark_client.conn.conf = mocker.stub("conf")
-        spark_client = SparkClient()
-        spark_client.write_dataframe = mocker.stub("write_dataframe")
-        writer = HistoricalFeatureStoreWriter()
-        feature_set_incremental._start_date = "2019-12-31"
-
-        # when
-        writer.write(
-            feature_set=feature_set_incremental,
-            dataframe=feature_set_dataframe,
-            spark_client=spark_client,
-        )
-        result_df = spark_client.write_dataframe.call_args[1]["dataframe"]
-
-        # then
-        assert_dataframe_equality(historical_feature_set_dataframe, result_df)

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -45,7 +45,7 @@ class TestHistoricalFeatureStoreWriter:
         )
         assert (
             writer.PARTITION_BY
-            == spark_client.write_dataframe.call_args[1]["partition_by"]
+            == spark_client.write_dataframe.call_args[1]["partitionBy"]
         )
 
     def test_write_invalid_partition_mode(
@@ -94,8 +94,8 @@ class TestHistoricalFeatureStoreWriter:
     def test_validate(self, feature_set_dataframe, mocker, feature_set):
         # given
         spark_client = mocker.stub("spark_client")
-        spark_client.read_table = mocker.stub("read_table")
-        spark_client.read_table.return_value = feature_set_dataframe
+        spark_client.read = mocker.stub("read")
+        spark_client.read.return_value = feature_set_dataframe
 
         writer = HistoricalFeatureStoreWriter()
 
@@ -103,15 +103,15 @@ class TestHistoricalFeatureStoreWriter:
         writer.validate(feature_set, feature_set_dataframe, spark_client)
 
         # then
-        spark_client.read_table.assert_called_once()
+        spark_client.read.assert_called_once()
 
     def test_validate_false(self, feature_set_dataframe, mocker, feature_set):
         # given
         spark_client = mocker.stub("spark_client")
-        spark_client.read_table = mocker.stub("read_table")
+        spark_client.read = mocker.stub("read")
 
         # limiting df to 1 row, now the counts should'n be the same
-        spark_client.read_table.return_value = feature_set_dataframe.limit(1)
+        spark_client.read.return_value = feature_set_dataframe.limit(1)
 
         writer = HistoricalFeatureStoreWriter()
 


### PR DESCRIPTION
## Why? :open_book:
We change the way of writing the Historical Feature Store Writer and also change the data partition insertion type.

## What? :wrench:
- HistoricalFSWriter with incremental mode

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How everything was tested? :straight_ruler:
- Unit tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.