### PR TITLE
Make pipelines aware of a timezone configuration

### DIFF
--- a/butterfree/pipelines/feature_set_pipeline.py
+++ b/butterfree/pipelines/feature_set_pipeline.py
@@ -1,4 +1,6 @@
 """FeatureSetPipeline entity."""
+import os
+import time
 from typing import List
 
 from butterfree.clients import SparkClient
@@ -16,6 +18,8 @@ class FeatureSetPipeline:
         feature_set: feature set composed by features and context metadata.
         sink: sink used to write the output dataframe in the desired locations.
         spark_client: client used to access Spark connection.
+        timezone: timestamp feature transformations will assume this timezone 
+            when they don't have a tz suffix.
 
     Example:
         This an example regarding the feature set pipeline definition. All
@@ -122,11 +126,25 @@ class FeatureSetPipeline:
         feature_set: FeatureSet,
         sink: Sink,
         spark_client: SparkClient = None,
+        timezone: str = "UTC",
     ):
         self.source = source
         self.feature_set = feature_set
         self.sink = sink
         self.spark_client = spark_client
+        self.timezone = timezone
+
+    @property
+    def timezone(self) -> str:
+        return self._timezone
+
+    @timezone.setter
+    def timezone(self, value: str):
+        if value:
+            self.spark_client.conn.conf.set("spark.sql.session.timeZone", value)
+            os.environ["TZ"] = value
+            time.tzset()
+        self._timezone = value
 
     @property
     def source(self) -> Source:


### PR DESCRIPTION
## Why? :open_book:
While Spark's TimestampType timezone is controlled by the `spark.sql.session.timeZone` configuration option, python's datetime objects have their timezone controlled by the system's timezone (when they don't have a fixed tz suffix). This means some transformations can have their timestamps converted in different ways when running on different systems. 

An example of possible irregular results happens when we automatically set the `start_date` of `AggregatedFeatureSets` ([here](https://github.com/quintoandar/butterfree/blob/master/butterfree/transform/aggregated_feature_set.py#L332)). Sometimes the spark and the system can have different timezones, meaning that the timestamp coming from the spark dataframe, when collected into plain python as a datetime object can change, generating a `start_date` different then expected.

## What? :wrench:
This PR proposes to apply a timezone configuration that should be aware by each pipeline and that should be the same between spark and system. This timezone is configurable.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How everything was tested? :straight_ruler:
TODO.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
