### PR TITLE
[MLOP-534] Enable interval and full writing on writers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *.cover
 .hypothesis/
 *cov.xml
+test_folder/
 
 # Translations
 *.mo

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -235,11 +235,7 @@ class HistoricalFeatureStoreWriter(Writer):
                 self.db_config.format_, options=self.db_config.get_options(table_name),
             ).count()
             if self.interval_mode and not self.debug_mode
-            else (
-                spark_client.read_table(table_name).count()
-                if not self.debug_mode
-                else spark_client.read_table(table_name).count()
-            )
+            else spark_client.read_table(table_name).count()
         )
         dataframe_count = dataframe.count()
         self._assert_validation_count(table_name, written_count, dataframe_count)

--- a/butterfree/load/writers/online_feature_store_writer.py
+++ b/butterfree/load/writers/online_feature_store_writer.py
@@ -70,9 +70,15 @@ class OnlineFeatureStoreWriter(Writer):
 
     __name__ = "Online Feature Store Writer"
 
-    def __init__(self, db_config=None, debug_mode: bool = False, write_to_entity=False):
+    def __init__(
+        self,
+        db_config=None,
+        debug_mode: bool = False,
+        write_to_entity=False,
+        interval_mode: bool = False,
+    ):
+        super().__init__(debug_mode, interval_mode)
         self.db_config = db_config or CassandraConfig()
-        self.debug_mode = debug_mode
         self.write_to_entity = write_to_entity
 
     @staticmethod

--- a/butterfree/load/writers/writer.py
+++ b/butterfree/load/writers/writer.py
@@ -17,8 +17,10 @@ class Writer(ABC, HookableComponent):
 
     """
 
-    def __init__(self):
+    def __init__(self, debug_mode: bool = False, interval_mode: bool = False):
         super().__init__()
+        self.debug_mode = debug_mode
+        self.interval_mode = interval_mode
 
     @abstractmethod
     def write(

--- a/tests/integration/butterfree/load/test_sink.py
+++ b/tests/integration/butterfree/load/test_sink.py
@@ -26,7 +26,9 @@ def test_sink(input_dataframe, feature_set):
     s3config.get_options = Mock(
         return_value={"path": "test_folder/historical/entity/feature_set"}
     )
-    historical_writer = HistoricalFeatureStoreWriter(db_config=s3config)
+    historical_writer = HistoricalFeatureStoreWriter(
+        db_config=s3config, interval_mode=True
+    )
 
     # setup online writer
     # TODO: Change for CassandraConfig when Cassandra for test is ready

--- a/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
+++ b/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
@@ -117,7 +117,11 @@ class TestFeatureSetPipeline:
                 ],
                 timestamp=TimestampFeature(),
             ),
-            sink=Sink(writers=[HistoricalFeatureStoreWriter(db_config=dbconfig)],),
+            sink=Sink(
+                writers=[
+                    HistoricalFeatureStoreWriter(db_config=dbconfig, interval_mode=True)
+                ],
+            ),
         )
         test_pipeline.run()
 


### PR DESCRIPTION
## Why? :open_book:
The new argument on writers with a default set to True so we can maintain the same Butterfree functionality before the "Incremental Epic" release. This will be a temporary flag that will enable the "Feature toggle".

## What? :wrench:
- HistoricalFSWriter

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


## How everything was tested? :straight_ruler:
- Unit and integration tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
