### PR TITLE
[MLOP-538] Slice df between start_date and end_date at the output of the FeatureSet

### DIFF
--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -8,9 +8,8 @@ from pyspark import sql
 from pyspark.sql import DataFrame, functions
 
 from butterfree.clients import SparkClient
-from butterfree.constants.columns import TIMESTAMP_COLUMN
 from butterfree.constants.window_definitions import ALLOWED_WINDOWS
-from butterfree.dataframe_service import IncrementalStrategy, repartition_df
+from butterfree.dataframe_service import repartition_df
 from butterfree.transform import FeatureSet
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
 from butterfree.transform.transformations import AggregatedTransform
@@ -204,7 +203,6 @@ class AggregatedFeatureSet(FeatureSet):
         self._pivot_values = []
         self._distinct_subset = []
         self._distinct_keep = None
-        self.incremental_strategy = IncrementalStrategy(column=TIMESTAMP_COLUMN)
         super(AggregatedFeatureSet, self).__init__(
             name, entity, description, keys, timestamp, features,
         )
@@ -575,9 +573,7 @@ class AggregatedFeatureSet(FeatureSet):
         else:
             output_df = self._aggregate(output_df, features=self.features)
 
-        output_df = self.incremental_strategy.filter_with_incremental_strategy(
-            dataframe=output_df, start_date=start_date, end_date=end_date
-        )
+        output_df = self.filter_dataframe_by_date(output_df, start_date, end_date)
 
         output_df = output_df.select(*self.columns).replace(float("nan"), None)
         if not output_df.isStreaming:

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -573,7 +573,9 @@ class AggregatedFeatureSet(FeatureSet):
         else:
             output_df = self._aggregate(output_df, features=self.features)
 
-        output_df = self.filter_dataframe_by_date(output_df, start_date, end_date)
+        output_df = self.incremental_strategy.filter_with_incremental_strategy(
+            dataframe=output_df, start_date=start_date, end_date=end_date
+        )
 
         output_df = output_df.select(*self.columns).replace(float("nan"), None)
         if not output_df.isStreaming:

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -385,6 +385,16 @@ class FeatureSet(HookableComponent):
     def filter_dataframe_by_date(
         self, df, start_date: str = None, end_date: str = None
     ):
+        """Filter, based on a time period, a given dataframe.
+
+        Args:
+            df: dataframe.
+            start_date: start date regarding a given dataframe.
+            end_date: end data regarding a given dataframe.
+
+        Returns:
+            Filtered dataframe.
+        """
         return self.incremental_strategy.filter_with_incremental_strategy(
             dataframe=df, start_date=start_date, end_date=end_date
         )

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -382,23 +382,6 @@ class FeatureSet(HookableComponent):
 
         return df.select([column for column in self.columns])
 
-    def filter_dataframe_by_date(
-        self, df, start_date: str = None, end_date: str = None
-    ):
-        """Filter, based on a time period, a given dataframe.
-
-        Args:
-            df: dataframe.
-            start_date: start date regarding a given dataframe.
-            end_date: end data regarding a given dataframe.
-
-        Returns:
-            Filtered dataframe.
-        """
-        return self.incremental_strategy.filter_with_incremental_strategy(
-            dataframe=df, start_date=start_date, end_date=end_date
-        )
-
     def define_start_date(self, start_date: str = None):
         """Get feature set start date.
 
@@ -448,7 +431,9 @@ class FeatureSet(HookableComponent):
         if not output_df.isStreaming:
             output_df = self._filter_duplicated_rows(output_df)
 
-        output_df = self.filter_dataframe_by_date(output_df, start_date, end_date)
+        output_df = self.incremental_strategy.filter_with_incremental_strategy(
+            dataframe=output_df, start_date=start_date, end_date=end_date
+        )
 
         post_hook_df = self.run_post_hooks(output_df)
 

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -9,6 +9,7 @@ from pyspark.sql.dataframe import DataFrame
 
 from butterfree.clients import SparkClient
 from butterfree.constants.columns import TIMESTAMP_COLUMN
+from butterfree.dataframe_service import IncrementalStrategy
 from butterfree.hooks import HookableComponent
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
 from butterfree.transform.transformations import (
@@ -114,6 +115,7 @@ class FeatureSet(HookableComponent):
         self.keys = keys
         self.timestamp = timestamp
         self.features = features
+        self.incremental_strategy = IncrementalStrategy(column=TIMESTAMP_COLUMN)
 
     @property
     def name(self) -> str:
@@ -380,6 +382,13 @@ class FeatureSet(HookableComponent):
 
         return df.select([column for column in self.columns])
 
+    def filter_dataframe_by_date(
+        self, df, start_date: str = None, end_date: str = None
+    ):
+        return self.incremental_strategy.filter_with_incremental_strategy(
+            dataframe=df, start_date=start_date, end_date=end_date
+        )
+
     def define_start_date(self, start_date: str = None):
         """Get feature set start date.
 
@@ -428,6 +437,8 @@ class FeatureSet(HookableComponent):
 
         if not output_df.isStreaming:
             output_df = self._filter_duplicated_rows(output_df)
+
+        output_df = self.filter_dataframe_by_date(output_df, start_date, end_date)
 
         post_hook_df = self.run_post_hooks(output_df)
 

--- a/tests/integration/butterfree/transform/conftest.py
+++ b/tests/integration/butterfree/transform/conftest.py
@@ -413,6 +413,18 @@ def feature_set_dates_dataframe(spark_context, spark_session):
 
 
 @fixture
+def feature_set_dates_output_dataframe(spark_context, spark_session):
+    data = [
+        {"id": 1, "timestamp": "2016-04-11 11:31:11", "feature": 200},
+        {"id": 1, "timestamp": "2016-04-12 11:44:12", "feature": 300},
+    ]
+    df = spark_session.read.json(spark_context.parallelize(data, 1))
+    df = df.withColumn("timestamp", df.timestamp.cast(DataType.TIMESTAMP.spark))
+
+    return df
+
+
+@fixture
 def rolling_windows_output_date_boundaries(spark_context, spark_session):
     data = [
         {

--- a/tests/integration/butterfree/transform/test_feature_set.py
+++ b/tests/integration/butterfree/transform/test_feature_set.py
@@ -77,3 +77,47 @@ class TestFeatureSet:
 
         # assert
         assert_dataframe_equality(output_df, target_df)
+
+    def test_construct_with_date_boundaries(
+        self, feature_set_dates_dataframe, feature_set_dates_output_dataframe
+    ):
+        # given
+
+        spark_client = SparkClient()
+
+        # arrange
+
+        feature_set = FeatureSet(
+            name="feature_set",
+            entity="entity",
+            description="description",
+            features=[
+                Feature(name="feature", description="test", dtype=DataType.FLOAT,),
+            ],
+            keys=[
+                KeyFeature(
+                    name="id",
+                    description="The user's Main ID or device ID",
+                    dtype=DataType.INTEGER,
+                )
+            ],
+            timestamp=TimestampFeature(),
+        )
+
+        output_df = (
+            feature_set.construct(
+                feature_set_dates_dataframe,
+                client=spark_client,
+                start_date="2016-04-11",
+                end_date="2016-04-12",
+            )
+            .orderBy(feature_set.timestamp_column)
+            .select(feature_set.columns)
+        )
+
+        target_df = feature_set_dates_output_dataframe.orderBy(
+            feature_set.timestamp_column
+        ).select(feature_set.columns)
+
+        # assert
+        assert_dataframe_equality(output_df, target_df)


### PR DESCRIPTION
## Why? :open_book:
Added a time filtering method inside ```FeatureSet```.

## What? :wrench:
Added a time filtering method inside ```FeatureSet```.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Integration tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [ ] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

