### PR TITLE
[MLOP-540] Update Docstrings on OnlineFeatureStoreWriter regarding using end_date parameter

### DIFF
--- a/butterfree/load/writers/online_feature_store_writer.py
+++ b/butterfree/load/writers/online_feature_store_writer.py
@@ -69,6 +69,7 @@ class OnlineFeatureStoreWriter(Writer):
         There's an important aspect to be highlighted here: if you're using
         the incremental mode, we do not check if your data is the newest before
         writing to the online feature store.
+
         This behavior is known and will be fixed soon.
     """
 

--- a/butterfree/load/writers/online_feature_store_writer.py
+++ b/butterfree/load/writers/online_feature_store_writer.py
@@ -66,6 +66,10 @@ class OnlineFeatureStoreWriter(Writer):
         Both methods (writer and validate) will need the Spark Client,
         Feature Set and DataFrame, to write or to validate,
         according to OnlineFeatureStoreWriter class arguments.
+        There's an important aspect to be highlighted here: if you're using
+        the incremental mode, we do not check if your data is the newest before
+        writing to the online feature store.
+        This behavior is known and will be fixed soon.
     """
 
     __name__ = "Online Feature Store Writer"


### PR DESCRIPTION
## Why? :open_book:
Currently, we do not guarantee if your data is the newest one when writing in the online feature store. This happens because we perform full loads. However, even for incremental loads, we're not going to perform any checks for now (well fix this behavior soon).

## What? :wrench:
Update docstring within the scope of the Online Writer explaining the current situation.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

