### PR TITLE
[MLOP-539] Fix validate on HistoricalFeatureStore for interval writing

### DIFF
--- a/butterfree/clients/spark_client.py
+++ b/butterfree/clients/spark_client.py
@@ -34,9 +34,10 @@ class SparkClient(AbstractClient):
     def read(
         self,
         format: str,
-        options: Dict[str, Any],
+        path: Any = None,
         schema: Optional[StructType] = None,
         stream: bool = False,
+        **options: Any,
     ) -> DataFrame:
         """Use the SparkSession.read interface to load data into a dataframe.
 
@@ -45,9 +46,10 @@ class SparkClient(AbstractClient):
 
         Args:
             format: string with the format to be used by the DataframeReader.
-            options: options to setup the DataframeReader.
             stream:  flag to indicate if data must be read in stream mode.
             schema: an optional pyspark.sql.types.StructType for the input schema.
+            path: optional string or a list of string for file-system.
+            options: options to setup the DataframeReader.
 
         Returns:
             Dataframe
@@ -55,14 +57,14 @@ class SparkClient(AbstractClient):
         """
         if not isinstance(format, str):
             raise ValueError("format needs to be a string with the desired read format")
-        if not isinstance(options, dict):
-            raise ValueError("options needs to be a dict with the setup configurations")
+        if not isinstance(path, (str, list)):
+            raise ValueError("path needs to be a string or a list of string")
 
         df_reader: Union[
             DataStreamReader, DataFrameReader
         ] = self.conn.readStream if stream else self.conn.read
         df_reader = df_reader.schema(schema) if schema else df_reader
-        return df_reader.format(format).options(**options).load()
+        return df_reader.format(format).load(path, **options)
 
     def read_table(self, table: str, database: str = None) -> DataFrame:
         """Use the SparkSession.read interface to read a metastore table.

--- a/butterfree/configs/db/s3_config.py
+++ b/butterfree/configs/db/s3_config.py
@@ -7,6 +7,7 @@ from pyspark.sql import DataFrame
 
 from butterfree.configs import environment
 from butterfree.configs.db import AbstractWriteConfig
+from butterfree.dataframe_service import extract_partition_values
 
 
 class S3Config(AbstractWriteConfig):
@@ -86,13 +87,14 @@ class S3Config(AbstractWriteConfig):
             A list of string for file-system backed data sources.
         """
         path_list = []
-        for row in dataframe.collect():
-            path = (
+        dataframe_values = extract_partition_values(
+            dataframe, partition_columns=["year", "month", "day"]
+        )
+        for row in dataframe_values:
+            path_list.append(
                 f"s3a://{self.bucket}/{key}/year={row['year']}/"
                 f"month={row['month']}/day={row['day']}"
             )
-            if path not in path_list:
-                path_list.append(path)
 
         return path_list
 

--- a/butterfree/extract/readers/file_reader.py
+++ b/butterfree/extract/readers/file_reader.py
@@ -86,9 +86,7 @@ class FileReader(Reader):
         self.path = path
         self.format = format
         self.schema = schema
-        self.options = dict(
-            {"path": self.path}, **format_options if format_options else {}
-        )
+        self.options = dict(format_options if format_options else {})
         self.stream = stream
 
     def consume(self, client: SparkClient) -> DataFrame:
@@ -105,11 +103,15 @@ class FileReader(Reader):
 
         """
         schema = (
-            client.read(format=self.format, options=self.options,).schema
+            client.read(format=self.format, path=self.path, **self.options).schema
             if (self.stream and not self.schema)
             else self.schema
         )
 
         return client.read(
-            format=self.format, options=self.options, schema=schema, stream=self.stream,
+            format=self.format,
+            schema=schema,
+            stream=self.stream,
+            path=self.path,
+            **self.options,
         )

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -241,7 +241,8 @@ class HistoricalFeatureStoreWriter(Writer):
         )
         written_count = (
             spark_client.read(
-                self.db_config.format_, options=self.db_config.get_options(table_name),
+                self.db_config.format_,
+                path=self.db_config.get_path_with_partitions(table_name, dataframe),
             ).count()
             if self.interval_mode and not self.debug_mode
             else spark_client.read_table(table_name).count()

--- a/tests/integration/butterfree/load/test_sink.py
+++ b/tests/integration/butterfree/load/test_sink.py
@@ -26,6 +26,9 @@ def test_sink(input_dataframe, feature_set, mocker):
     s3config.get_options = Mock(
         return_value={"path": "test_folder/historical/entity/feature_set"}
     )
+    s3config.get_path_with_partitions = Mock(
+        return_value="test_folder/historical/entity/feature_set"
+    )
 
     historical_writer = HistoricalFeatureStoreWriter(
         db_config=s3config, interval_mode=True
@@ -59,12 +62,13 @@ def test_sink(input_dataframe, feature_set, mocker):
 
     # get historical results
     historical_result_df = client.read(
-        s3config.format_, options=s3config.get_options(feature_set.name)
+        s3config.format_,
+        path=s3config.get_path_with_partitions(feature_set.name, feature_set_df),
     )
 
     # get online results
     online_result_df = client.read(
-        online_config.format_, options=online_config.get_options(feature_set.name)
+        online_config.format_, **online_config.get_options(feature_set.name)
     )
 
     # assert

--- a/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
+++ b/tests/integration/butterfree/pipelines/test_feature_set_pipeline.py
@@ -70,6 +70,11 @@ class TestFeatureSetPipeline:
         dbconfig.get_options = Mock(
             return_value={"path": "test_folder/historical/entity/feature_set"}
         )
+        dbconfig.get_path_with_partitions = Mock(
+            return_value=[
+                "test_folder/historical/entity/feature_set/year=2016/month=4/day=11"
+            ]
+        )
 
         historical_writer = HistoricalFeatureStoreWriter(
             db_config=dbconfig, interval_mode=True

--- a/tests/unit/butterfree/extract/readers/test_file_reader.py
+++ b/tests/unit/butterfree/extract/readers/test_file_reader.py
@@ -36,11 +36,11 @@ class TestFileReader:
 
         # act
         output_df = file_reader.consume(spark_client)
-        options = dict({"path": path}, **format_options if format_options else {})
+        options = dict(format_options if format_options else {})
 
         # assert
         spark_client.read.assert_called_once_with(
-            format=format, options=options, schema=schema, stream=False
+            format=format, schema=schema, stream=False, path=path, **options
         )
         assert target_df.collect() == output_df.collect()
 
@@ -51,7 +51,7 @@ class TestFileReader:
         schema = None
         format_options = None
         stream = True
-        options = dict({"path": path})
+        options = dict({})
 
         spark_client.read.return_value = target_df
         file_reader = FileReader(
@@ -64,11 +64,11 @@ class TestFileReader:
         # assert
 
         # assert call for schema infer
-        spark_client.read.assert_any_call(format=format, options=options)
+        spark_client.read.assert_any_call(format=format, path=path, **options)
         # assert call for stream read
         # stream
         spark_client.read.assert_called_with(
-            format=format, options=options, schema=output_df.schema, stream=stream
+            format=format, schema=output_df.schema, stream=stream, path=path, **options
         )
         assert target_df.collect() == output_df.collect()
 

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -178,47 +178,53 @@ class TestHistoricalFeatureStoreWriter:
             == "dynamic"
         )
 
-    def test_validate(self, feature_set_dataframe, mocker, feature_set):
+    def test_validate(self, historical_feature_set_dataframe, mocker, feature_set):
         # given
         spark_client = mocker.stub("spark_client")
         spark_client.read_table = mocker.stub("read_table")
-        spark_client.read_table.return_value = feature_set_dataframe
+        spark_client.read_table.return_value = historical_feature_set_dataframe
 
         writer = HistoricalFeatureStoreWriter()
 
         # when
-        writer.validate(feature_set, feature_set_dataframe, spark_client)
+        writer.validate(feature_set, historical_feature_set_dataframe, spark_client)
 
         # then
         spark_client.read_table.assert_called_once()
 
-    def test_validate_interval_mode(self, feature_set_dataframe, mocker, feature_set):
+    def test_validate_interval_mode(
+        self, historical_feature_set_dataframe, mocker, feature_set
+    ):
         # given
         spark_client = mocker.stub("spark_client")
         spark_client.read = mocker.stub("read")
-        spark_client.read.return_value = feature_set_dataframe
+        spark_client.read.return_value = historical_feature_set_dataframe
 
         writer = HistoricalFeatureStoreWriter(interval_mode=True)
 
         # when
-        writer.validate(feature_set, feature_set_dataframe, spark_client)
+        writer.validate(feature_set, historical_feature_set_dataframe, spark_client)
 
         # then
         spark_client.read.assert_called_once()
 
-    def test_validate_false(self, feature_set_dataframe, mocker, feature_set):
+    def test_validate_false(
+        self, historical_feature_set_dataframe, mocker, feature_set
+    ):
         # given
         spark_client = mocker.stub("spark_client")
         spark_client.read = mocker.stub("read")
 
         # limiting df to 1 row, now the counts should'n be the same
-        spark_client.read.return_value = feature_set_dataframe.limit(1)
+        spark_client.read.return_value = historical_feature_set_dataframe.limit(1)
 
         writer = HistoricalFeatureStoreWriter(interval_mode=True)
 
         # when
         with pytest.raises(AssertionError):
-            _ = writer.validate(feature_set, feature_set_dataframe, spark_client)
+            _ = writer.validate(
+                feature_set, historical_feature_set_dataframe, spark_client
+            )
 
     def test__create_partitions(self, spark_session, spark_context):
         # arrange

--- a/tests/unit/butterfree/pipelines/conftest.py
+++ b/tests/unit/butterfree/pipelines/conftest.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock
+
+from pyspark.sql import functions
+from pytest import fixture
+
+from butterfree.clients import SparkClient
+from butterfree.constants import DataType
+from butterfree.constants.columns import TIMESTAMP_COLUMN
+from butterfree.extract import Source
+from butterfree.extract.readers import TableReader
+from butterfree.load import Sink
+from butterfree.load.writers import HistoricalFeatureStoreWriter
+from butterfree.pipelines import FeatureSetPipeline
+from butterfree.transform import FeatureSet
+from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
+from butterfree.transform.transformations import SparkFunctionTransform
+from butterfree.transform.utils import Function
+
+
+@fixture()
+def feature_set_pipeline():
+    test_pipeline = FeatureSetPipeline(
+        spark_client=SparkClient(),
+        source=Mock(
+            spec=Source,
+            readers=[TableReader(id="source_a", database="db", table="table",)],
+            query="select * from source_a",
+        ),
+        feature_set=Mock(
+            spec=FeatureSet,
+            name="feature_set",
+            entity="entity",
+            description="description",
+            keys=[
+                KeyFeature(
+                    name="user_id",
+                    description="The user's Main ID or device ID",
+                    dtype=DataType.INTEGER,
+                )
+            ],
+            timestamp=TimestampFeature(from_column="ts"),
+            features=[
+                Feature(
+                    name="listing_page_viewed__rent_per_month",
+                    description="Average of something.",
+                    transformation=SparkFunctionTransform(
+                        functions=[
+                            Function(functions.avg, DataType.FLOAT),
+                            Function(functions.stddev_pop, DataType.FLOAT),
+                        ],
+                    ).with_window(
+                        partition_by="user_id",
+                        order_by=TIMESTAMP_COLUMN,
+                        window_definition=["7 days", "2 weeks"],
+                        mode="fixed_windows",
+                    ),
+                ),
+            ],
+        ),
+        sink=Mock(spec=Sink, writers=[HistoricalFeatureStoreWriter(db_config=None)],),
+    )
+
+    return test_pipeline

--- a/tests/unit/butterfree/pipelines/test_feature_set_pipeline.py
+++ b/tests/unit/butterfree/pipelines/test_feature_set_pipeline.py
@@ -17,12 +17,8 @@ from butterfree.load.writers import (
 from butterfree.load.writers.writer import Writer
 from butterfree.pipelines.feature_set_pipeline import FeatureSetPipeline
 from butterfree.transform import FeatureSet
-from butterfree.transform.aggregated_feature_set import AggregatedFeatureSet
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
-from butterfree.transform.transformations import (
-    AggregatedTransform,
-    SparkFunctionTransform,
-)
+from butterfree.transform.transformations import SparkFunctionTransform
 from butterfree.transform.utils import Function
 
 
@@ -104,115 +100,29 @@ class TestFeatureSetPipeline:
         assert len(pipeline.sink.writers) == 2
         assert all(isinstance(writer, Writer) for writer in pipeline.sink.writers)
 
-    def test_run(self, spark_session):
-        test_pipeline = FeatureSetPipeline(
-            spark_client=SparkClient(),
-            source=Mock(
-                spec=Source,
-                readers=[TableReader(id="source_a", database="db", table="table",)],
-                query="select * from source_a",
-            ),
-            feature_set=Mock(
-                spec=FeatureSet,
-                name="feature_set",
-                entity="entity",
-                description="description",
-                keys=[
-                    KeyFeature(
-                        name="user_id",
-                        description="The user's Main ID or device ID",
-                        dtype=DataType.INTEGER,
-                    )
-                ],
-                timestamp=TimestampFeature(from_column="ts"),
-                features=[
-                    Feature(
-                        name="listing_page_viewed__rent_per_month",
-                        description="Average of something.",
-                        transformation=SparkFunctionTransform(
-                            functions=[
-                                Function(functions.avg, DataType.FLOAT),
-                                Function(functions.stddev_pop, DataType.FLOAT),
-                            ],
-                        ).with_window(
-                            partition_by="user_id",
-                            order_by=TIMESTAMP_COLUMN,
-                            window_definition=["7 days", "2 weeks"],
-                            mode="fixed_windows",
-                        ),
-                    ),
-                ],
-            ),
-            sink=Mock(
-                spec=Sink, writers=[HistoricalFeatureStoreWriter(db_config=None)],
-            ),
-        )
-
+    def test_run(self, spark_session, feature_set_pipeline):
         # feature_set need to return a real df for streaming validation
         sample_df = spark_session.createDataFrame([{"a": "x", "b": "y", "c": "3"}])
-        test_pipeline.feature_set.construct.return_value = sample_df
+        feature_set_pipeline.feature_set.construct.return_value = sample_df
 
-        test_pipeline.run()
+        feature_set_pipeline.run()
 
-        test_pipeline.source.construct.assert_called_once()
-        test_pipeline.feature_set.construct.assert_called_once()
-        test_pipeline.sink.flush.assert_called_once()
-        test_pipeline.sink.validate.assert_called_once()
+        feature_set_pipeline.source.construct.assert_called_once()
+        feature_set_pipeline.feature_set.construct.assert_called_once()
+        feature_set_pipeline.sink.flush.assert_called_once()
+        feature_set_pipeline.sink.validate.assert_called_once()
 
-    def test_run_with_repartition(self, spark_session):
-        test_pipeline = FeatureSetPipeline(
-            spark_client=SparkClient(),
-            source=Mock(
-                spec=Source,
-                readers=[TableReader(id="source_a", database="db", table="table",)],
-                query="select * from source_a",
-            ),
-            feature_set=Mock(
-                spec=FeatureSet,
-                name="feature_set",
-                entity="entity",
-                description="description",
-                keys=[
-                    KeyFeature(
-                        name="user_id",
-                        description="The user's Main ID or device ID",
-                        dtype=DataType.INTEGER,
-                    )
-                ],
-                timestamp=TimestampFeature(from_column="ts"),
-                features=[
-                    Feature(
-                        name="listing_page_viewed__rent_per_month",
-                        description="Average of something.",
-                        transformation=SparkFunctionTransform(
-                            functions=[
-                                Function(functions.avg, DataType.FLOAT),
-                                Function(functions.stddev_pop, DataType.FLOAT),
-                            ],
-                        ).with_window(
-                            partition_by="user_id",
-                            order_by=TIMESTAMP_COLUMN,
-                            window_definition=["7 days", "2 weeks"],
-                            mode="fixed_windows",
-                        ),
-                    ),
-                ],
-            ),
-            sink=Mock(
-                spec=Sink, writers=[HistoricalFeatureStoreWriter(db_config=None)],
-            ),
-        )
-
+    def test_run_with_repartition(self, spark_session, feature_set_pipeline):
         # feature_set need to return a real df for streaming validation
         sample_df = spark_session.createDataFrame([{"a": "x", "b": "y", "c": "3"}])
-        test_pipeline.feature_set.construct.return_value = sample_df
+        feature_set_pipeline.feature_set.construct.return_value = sample_df
 
-        test_pipeline.run(partition_by=["id"])
+        feature_set_pipeline.run(partition_by=["id"])
 
-        test_pipeline.source.construct.assert_called_once()
-        test_pipeline.feature_set.construct.assert_called_once()
-        test_pipeline.sink.flush.assert_called_once()
-        test_pipeline.sink.validate.assert_called_once()
+        feature_set_pipeline.source.construct.assert_called_once()
+        feature_set_pipeline.feature_set.construct.assert_called_once()
+        feature_set_pipeline.sink.flush.assert_called_once()
+        feature_set_pipeline.sink.validate.assert_called_once()
 
     def test_source_raise(self):
         with pytest.raises(ValueError, match="source must be a Source instance"):
@@ -343,102 +253,26 @@ class TestFeatureSetPipeline:
                 sink=Mock(writers=[HistoricalFeatureStoreWriter(db_config=None)],),
             )
 
-    def test_run_agg_with_end_date(self, spark_session):
-        test_pipeline = FeatureSetPipeline(
-            spark_client=SparkClient(),
-            source=Mock(
-                spec=Source,
-                readers=[TableReader(id="source_a", database="db", table="table",)],
-                query="select * from source_a",
-            ),
-            feature_set=Mock(
-                spec=AggregatedFeatureSet,
-                name="feature_set",
-                entity="entity",
-                description="description",
-                keys=[
-                    KeyFeature(
-                        name="user_id",
-                        description="The user's Main ID or device ID",
-                        dtype=DataType.INTEGER,
-                    )
-                ],
-                timestamp=TimestampFeature(from_column="ts"),
-                features=[
-                    Feature(
-                        name="listing_page_viewed__rent_per_month",
-                        description="Average of something.",
-                        transformation=AggregatedTransform(
-                            functions=[
-                                Function(functions.avg, DataType.FLOAT),
-                                Function(functions.stddev_pop, DataType.FLOAT),
-                            ],
-                        ),
-                    ),
-                ],
-            ),
-            sink=Mock(
-                spec=Sink, writers=[HistoricalFeatureStoreWriter(db_config=None)],
-            ),
-        )
-
+    def test_run_agg_with_end_date(self, spark_session, feature_set_pipeline):
         # feature_set need to return a real df for streaming validation
         sample_df = spark_session.createDataFrame([{"a": "x", "b": "y", "c": "3"}])
-        test_pipeline.feature_set.construct.return_value = sample_df
+        feature_set_pipeline.feature_set.construct.return_value = sample_df
 
-        test_pipeline.run(end_date="2016-04-18")
+        feature_set_pipeline.run(end_date="2016-04-18")
 
-        test_pipeline.source.construct.assert_called_once()
-        test_pipeline.feature_set.construct.assert_called_once()
-        test_pipeline.sink.flush.assert_called_once()
-        test_pipeline.sink.validate.assert_called_once()
+        feature_set_pipeline.source.construct.assert_called_once()
+        feature_set_pipeline.feature_set.construct.assert_called_once()
+        feature_set_pipeline.sink.flush.assert_called_once()
+        feature_set_pipeline.sink.validate.assert_called_once()
 
-    def test_run_agg_with_start_date(self, spark_session):
-        test_pipeline = FeatureSetPipeline(
-            spark_client=SparkClient(),
-            source=Mock(
-                spec=Source,
-                readers=[TableReader(id="source_a", database="db", table="table",)],
-                query="select * from source_a",
-            ),
-            feature_set=Mock(
-                spec=AggregatedFeatureSet,
-                name="feature_set",
-                entity="entity",
-                description="description",
-                keys=[
-                    KeyFeature(
-                        name="user_id",
-                        description="The user's Main ID or device ID",
-                        dtype=DataType.INTEGER,
-                    )
-                ],
-                timestamp=TimestampFeature(from_column="ts"),
-                features=[
-                    Feature(
-                        name="listing_page_viewed__rent_per_month",
-                        description="Average of something.",
-                        transformation=AggregatedTransform(
-                            functions=[
-                                Function(functions.avg, DataType.FLOAT),
-                                Function(functions.stddev_pop, DataType.FLOAT),
-                            ],
-                        ),
-                    ),
-                ],
-            ),
-            sink=Mock(
-                spec=Sink, writers=[HistoricalFeatureStoreWriter(db_config=None)],
-            ),
-        )
-
+    def test_run_agg_with_start_date(self, spark_session, feature_set_pipeline):
         # feature_set need to return a real df for streaming validation
         sample_df = spark_session.createDataFrame([{"a": "x", "b": "y", "c": "3"}])
-        test_pipeline.feature_set.construct.return_value = sample_df
+        feature_set_pipeline.feature_set.construct.return_value = sample_df
 
-        test_pipeline.run(start_date="2020-08-04")
+        feature_set_pipeline.run(start_date="2020-08-04")
 
-        test_pipeline.source.construct.assert_called_once()
-        test_pipeline.feature_set.construct.assert_called_once()
-        test_pipeline.sink.flush.assert_called_once()
-        test_pipeline.sink.validate.assert_called_once()
+        feature_set_pipeline.source.construct.assert_called_once()
+        feature_set_pipeline.feature_set.construct.assert_called_once()
+        feature_set_pipeline.sink.flush.assert_called_once()
+        feature_set_pipeline.sink.validate.assert_called_once()

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -89,7 +89,7 @@ class TestAggregatedFeatureSet:
         output_df = fs.construct(dataframe, spark_client, end_date="2016-05-01")
         assert_dataframe_equality(output_df, rolling_windows_agg_dataframe)
 
-    def test_get_schema(self):
+    def test_get_schema(self, agg_feature_set):
         expected_schema = [
             {"column_name": "id", "type": LongType(), "primary_key": True},
             {"column_name": "timestamp", "type": TimestampType(), "primary_key": False},
@@ -125,40 +125,7 @@ class TestAggregatedFeatureSet:
             },
         ]
 
-        feature_set = AggregatedFeatureSet(
-            name="feature_set",
-            entity="entity",
-            description="description",
-            features=[
-                Feature(
-                    name="feature1",
-                    description="test",
-                    transformation=AggregatedTransform(
-                        functions=[
-                            Function(functions.avg, DataType.DOUBLE),
-                            Function(functions.stddev_pop, DataType.FLOAT),
-                        ],
-                    ),
-                ),
-                Feature(
-                    name="feature2",
-                    description="test",
-                    transformation=AggregatedTransform(
-                        functions=[Function(functions.count, DataType.ARRAY_STRING)]
-                    ),
-                ),
-            ],
-            keys=[
-                KeyFeature(
-                    name="id",
-                    description="The user's Main ID or device ID",
-                    dtype=DataType.BIGINT,
-                )
-            ],
-            timestamp=TimestampFeature(),
-        ).with_windows(definitions=["1 week", "2 days"])
-
-        schema = feature_set.get_schema()
+        schema = agg_feature_set.get_schema()
 
         assert schema == expected_schema
 
@@ -390,41 +357,9 @@ class TestAggregatedFeatureSet:
         # assert
         assert_dataframe_equality(target_df, output_df)
 
-    def test_define_start_date(self):
-        feature_set = AggregatedFeatureSet(
-            name="feature_set",
-            entity="entity",
-            description="description",
-            features=[
-                Feature(
-                    name="feature1",
-                    description="test",
-                    transformation=AggregatedTransform(
-                        functions=[
-                            Function(functions.avg, DataType.DOUBLE),
-                            Function(functions.stddev_pop, DataType.FLOAT),
-                        ],
-                    ),
-                ),
-                Feature(
-                    name="feature2",
-                    description="test",
-                    transformation=AggregatedTransform(
-                        functions=[Function(functions.count, DataType.ARRAY_STRING)]
-                    ),
-                ),
-            ],
-            keys=[
-                KeyFeature(
-                    name="id",
-                    description="The user's Main ID or device ID",
-                    dtype=DataType.BIGINT,
-                )
-            ],
-            timestamp=TimestampFeature(),
-        ).with_windows(definitions=["1 week", "2 days"])
+    def test_define_start_date(self, agg_feature_set):
 
-        start_date = feature_set.define_start_date("2020-08-04")
+        start_date = agg_feature_set.define_start_date("2020-08-04")
 
         assert isinstance(start_date, str)
         assert start_date == "2020-07-27"

--- a/tests/unit/butterfree/transform/test_feature_set.py
+++ b/tests/unit/butterfree/transform/test_feature_set.py
@@ -12,13 +12,11 @@ from tests.unit.butterfree.transform.conftest import (
 
 from butterfree.clients import SparkClient
 from butterfree.constants import DataType
-from butterfree.constants.columns import TIMESTAMP_COLUMN
 from butterfree.testing.dataframe import assert_dataframe_equality
 from butterfree.transform import FeatureSet
-from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
+from butterfree.transform.features import Feature
 from butterfree.transform.transformations import (
     AggregatedTransform,
-    SparkFunctionTransform,
     SQLExpressionTransform,
 )
 from butterfree.transform.utils import Function
@@ -340,7 +338,7 @@ class TestFeatureSet:
                 timestamp=timestamp_c,
             ).construct(dataframe, spark_client)
 
-    def test_get_schema(self):
+    def test_get_schema(self, feature_set):
         expected_schema = [
             {"column_name": "id", "type": LongType(), "primary_key": True},
             {"column_name": "timestamp", "type": TimestampType(), "primary_key": False},
@@ -366,37 +364,6 @@ class TestFeatureSet:
             },
         ]
 
-        feature_set = FeatureSet(
-            name="feature_set",
-            entity="entity",
-            description="description",
-            features=[
-                Feature(
-                    name="feature1",
-                    description="test",
-                    transformation=SparkFunctionTransform(
-                        functions=[
-                            Function(F.avg, DataType.FLOAT),
-                            Function(F.stddev_pop, DataType.DOUBLE),
-                        ]
-                    ).with_window(
-                        partition_by="id",
-                        order_by=TIMESTAMP_COLUMN,
-                        mode="fixed_windows",
-                        window_definition=["2 minutes", "15 minutes"],
-                    ),
-                ),
-            ],
-            keys=[
-                KeyFeature(
-                    name="id",
-                    description="The user's Main ID or device ID",
-                    dtype=DataType.BIGINT,
-                )
-            ],
-            timestamp=TimestampFeature(),
-        )
-
         schema = feature_set.get_schema()
 
         assert schema == expected_schema
@@ -421,37 +388,7 @@ class TestFeatureSet:
                 timestamp=timestamp_c,
             ).construct(dataframe, spark_client)
 
-    def test_define_start_date(self, key_id, timestamp_c, dataframe):
-        feature_set = FeatureSet(
-            name="feature_set",
-            entity="entity",
-            description="description",
-            features=[
-                Feature(
-                    name="feature1",
-                    description="test",
-                    transformation=SparkFunctionTransform(
-                        functions=[
-                            Function(F.avg, DataType.FLOAT),
-                            Function(F.stddev_pop, DataType.DOUBLE),
-                        ]
-                    ).with_window(
-                        partition_by="id",
-                        order_by=TIMESTAMP_COLUMN,
-                        mode="fixed_windows",
-                        window_definition=["2 minutes", "15 minutes"],
-                    ),
-                ),
-            ],
-            keys=[
-                KeyFeature(
-                    name="id",
-                    description="The user's Main ID or device ID",
-                    dtype=DataType.BIGINT,
-                )
-            ],
-            timestamp=TimestampFeature(),
-        )
+    def test_define_start_date(self, feature_set):
 
         start_date = feature_set.define_start_date("2020-08-04")
 


### PR DESCRIPTION
## Why? :open_book:
When overwritten only the interval and not the table the validate functions need to readjust the written partitions and not the whole table.

## What? :wrench:
- SparkClient Read method
- HFSW Validate method

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How everything was tested? :straight_ruler:
- Unit and integration tests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.