### PR TITLE
[MLOP-563] Enable Butterfree to write to Kafka

### DIFF
--- a/butterfree/configs/db/__init__.py
+++ b/butterfree/configs/db/__init__.py
@@ -2,6 +2,7 @@
 
 from butterfree.configs.db.abstract_config import AbstractWriteConfig
 from butterfree.configs.db.cassandra_config import CassandraConfig
+from butterfree.configs.db.kafka_config import KafkaConfig
 from butterfree.configs.db.s3_config import S3Config
 
-__all__ = ["AbstractWriteConfig", "CassandraConfig", "S3Config"]
+__all__ = ["AbstractWriteConfig", "CassandraConfig", "KafkaConfig", "S3Config"]

--- a/butterfree/configs/db/abstract_config.py
+++ b/butterfree/configs/db/abstract_config.py
@@ -1,13 +1,14 @@
 """Abstract classes for database configurations with spark."""
 
-from abc import ABC, abstractmethod, abstractproperty
+from abc import ABC, abstractmethod
 from typing import Dict, List
 
 
 class AbstractWriteConfig(ABC):
     """Abstract class for database write configurations with spark."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def mode(self) -> str:
         """Config option "mode" for spark write.
 
@@ -18,7 +19,8 @@ class AbstractWriteConfig(ABC):
 
         """
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def format_(self) -> str:
         """Config option "format" for spark write.
 

--- a/butterfree/configs/db/kafka_config.py
+++ b/butterfree/configs/db/kafka_config.py
@@ -116,4 +116,16 @@ class KafkaConfig(AbstractWriteConfig):
         }
 
     def translate(self, schema) -> List[Dict]:
+        """Get feature set schema to be translated.
+
+        The output will be a list of dictionaries regarding cassandra
+        database schema.
+
+        Args:
+            schema: feature set schema in spark.
+
+        Returns:
+            Kafka schema.
+
+        """
         pass

--- a/butterfree/configs/db/kafka_config.py
+++ b/butterfree/configs/db/kafka_config.py
@@ -9,7 +9,7 @@ class KafkaConfig(AbstractWriteConfig):
     """Configuration for Spark to connect to Kafka.
 
     Attributes:
-        kafka_connection_string: kafka topic name.
+        kafka_connection_string: string with hosts and ports to connect.
         mode: write mode for Spark.
         format_: write format for Spark.
         stream_processing_time: processing time interval for streaming jobs.
@@ -45,7 +45,7 @@ class KafkaConfig(AbstractWriteConfig):
 
     @kafka_connection_string.setter
     def kafka_connection_string(self, value: str):
-        input_value = value or environment.get_variable("KAFKA_CONNECTION_STRING")
+        input_value = value or environment.get_variable("KAFKA_CONSUMER_CONNECTION_STRING")
         if input_value is None:
             raise ValueError("Config 'kafka connection string' cannot be empty.")
         self.__kafka_connection_string = input_value
@@ -97,21 +97,21 @@ class KafkaConfig(AbstractWriteConfig):
     def stream_processing_time(self, value: str):
         self.__stream_processing_time = value or "0 seconds"
 
-    def get_options(self, table: str) -> dict:
+    def get_options(self, topic: str) -> dict:
         """Get options for connecting to Kafka.
 
         Options will be a dictionary with the write and read configuration for
         spark to kafka.
 
         Args:
-            table: table name (topic) into Kafka.
+            topic: topic related to Kafka.
 
         Returns:
             Configuration to connect to Kafka.
 
         """
         return {
-            "topic": table,
+            "topic": topic,
             "kafka.bootstrap.servers": self.kafka_connection_string,
         }
 

--- a/butterfree/configs/db/kafka_config.py
+++ b/butterfree/configs/db/kafka_config.py
@@ -1,0 +1,119 @@
+"""Holds configurations to read and write with Spark to Cassandra DB."""
+from typing import Dict, List
+
+from butterfree.configs import environment
+from butterfree.configs.db import AbstractWriteConfig
+
+
+class KafkaConfig(AbstractWriteConfig):
+    """Configuration for Spark to connect to Kafka.
+
+    Attributes:
+        kafka_connection_string: kafka topic name.
+        mode: write mode for Spark.
+        format_: write format for Spark.
+        stream_processing_time: processing time interval for streaming jobs.
+        stream_output_mode: specify the mode from writing streaming data.
+        stream_checkpoint_path: path on S3 to save checkpoints for the stream job.
+
+    More information about processing_time, output_mode and checkpoint_path
+    can be found in Spark documentation:
+    [here](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html)
+
+    """
+
+    def __init__(
+        self,
+        kafka_connection_string: str = None,
+        mode: str = None,
+        format_: str = None,
+        stream_processing_time: str = None,
+        stream_output_mode: str = None,
+        stream_checkpoint_path: str = None,
+    ):
+        self.kafka_connection_string = kafka_connection_string
+        self.mode = mode
+        self.format_ = format_
+        self.stream_processing_time = stream_processing_time
+        self.stream_output_mode = stream_output_mode
+        self.stream_checkpoint_path = stream_checkpoint_path
+
+    @property
+    def kafka_connection_string(self) -> str:
+        """Username used in connection to Cassandra DB."""
+        return self.__kafka_connection_string
+
+    @kafka_connection_string.setter
+    def kafka_connection_string(self, value: str):
+        input_value = value or environment.get_variable("KAFKA_CONNECTION_STRING")
+        if input_value is None:
+            raise ValueError("Config 'kafka connection string' cannot be empty.")
+        self.__kafka_connection_string = input_value
+
+    @property
+    def format_(self) -> str:
+        """Write format for Spark."""
+        return self.__format
+
+    @format_.setter
+    def format_(self, value: str):
+        self.__format = value or "kafka"
+
+    @property
+    def mode(self) -> str:
+        """Write mode for Spark."""
+        return self.__mode
+
+    @mode.setter
+    def mode(self, value):
+        self.__mode = value or "append"
+
+    @property
+    def stream_processing_time(self) -> str:
+        """Processing time interval for streaming jobs."""
+        return self.__stream_processing_time
+
+    @stream_processing_time.setter
+    def stream_processing_time(self, value: str):
+        self.__stream_processing_time = value or "0 seconds"
+
+    @property
+    def stream_output_mode(self) -> str:
+        """Specify the mode from writing streaming data."""
+        return self.__stream_output_mode
+
+    @stream_output_mode.setter
+    def stream_output_mode(self, value: str):
+        self.__stream_output_mode = value or "update"
+
+    @property
+    def stream_checkpoint_path(self) -> str:
+        """Path on S3 to save checkpoints for the stream job."""
+        return self.__stream_checkpoint_path
+
+    @stream_checkpoint_path.setter
+    def stream_checkpoint_path(self, value: str):
+        self.__stream_checkpoint_path = value or environment.get_variable(
+            "STREAM_CHECKPOINT_PATH"
+        )
+
+    def get_options(self, table: str) -> dict:
+        """Get options for connecting to Kafka.
+
+        Options will be a dictionary with the write and read configuration for
+        spark to kafka.
+
+        Args:
+            table: table name (topic) into Kafka.
+
+        Returns:
+            Configuration to connect to Kafka.
+
+        """
+        return {
+            "topic": table,
+            "kafka.bootstrap.servers": self.kafka_connection_string,
+        }
+
+    def translate(self, schema) -> List[Dict]:
+        pass

--- a/butterfree/configs/db/kafka_config.py
+++ b/butterfree/configs/db/kafka_config.py
@@ -45,7 +45,9 @@ class KafkaConfig(AbstractWriteConfig):
 
     @kafka_connection_string.setter
     def kafka_connection_string(self, value: str):
-        input_value = value or environment.get_variable("KAFKA_CONSUMER_CONNECTION_STRING")
+        input_value = value or environment.get_variable(
+            "KAFKA_CONSUMER_CONNECTION_STRING"
+        )
         if input_value is None:
             raise ValueError("Config 'kafka connection string' cannot be empty.")
         self.__kafka_connection_string = input_value

--- a/butterfree/configs/db/kafka_config.py
+++ b/butterfree/configs/db/kafka_config.py
@@ -1,4 +1,4 @@
-"""Holds configurations to read and write with Spark to Cassandra DB."""
+"""Holds configurations to read and write with Spark to Kafka."""
 from typing import Dict, List
 
 from butterfree.configs import environment
@@ -51,15 +51,6 @@ class KafkaConfig(AbstractWriteConfig):
         self.__kafka_connection_string = input_value
 
     @property
-    def format_(self) -> str:
-        """Write format for Spark."""
-        return self.__format
-
-    @format_.setter
-    def format_(self, value: str):
-        self.__format = value or "kafka"
-
-    @property
     def mode(self) -> str:
         """Write mode for Spark."""
         return self.__mode
@@ -69,13 +60,13 @@ class KafkaConfig(AbstractWriteConfig):
         self.__mode = value or "append"
 
     @property
-    def stream_processing_time(self) -> str:
-        """Processing time interval for streaming jobs."""
-        return self.__stream_processing_time
+    def format_(self) -> str:
+        """Write format for Spark."""
+        return self.__format
 
-    @stream_processing_time.setter
-    def stream_processing_time(self, value: str):
-        self.__stream_processing_time = value or "0 seconds"
+    @format_.setter
+    def format_(self, value: str):
+        self.__format = value or "kafka"
 
     @property
     def stream_output_mode(self) -> str:
@@ -96,6 +87,15 @@ class KafkaConfig(AbstractWriteConfig):
         self.__stream_checkpoint_path = value or environment.get_variable(
             "STREAM_CHECKPOINT_PATH"
         )
+
+    @property
+    def stream_processing_time(self) -> str:
+        """Processing time interval for streaming jobs."""
+        return self.__stream_processing_time
+
+    @stream_processing_time.setter
+    def stream_processing_time(self, value: str):
+        self.__stream_processing_time = value or "0 seconds"
 
     def get_options(self, table: str) -> dict:
         """Get options for connecting to Kafka.

--- a/butterfree/configs/environment.py
+++ b/butterfree/configs/environment.py
@@ -11,6 +11,7 @@ specification = {
     "FEATURE_STORE_HISTORICAL_DATABASE": "test",
     "KAFKA_CONSUMER_CONNECTION_STRING": "test_host:1234,test_host2:1234",
     "STREAM_CHECKPOINT_PATH": None,
+    "KAFKA_CONNECTION_STRING": "test",
 }
 
 

--- a/butterfree/configs/environment.py
+++ b/butterfree/configs/environment.py
@@ -11,7 +11,6 @@ specification = {
     "FEATURE_STORE_HISTORICAL_DATABASE": "test",
     "KAFKA_CONSUMER_CONNECTION_STRING": "test_host:1234,test_host2:1234",
     "STREAM_CHECKPOINT_PATH": None,
-    "KAFKA_CONNECTION_STRING": "test",
 }
 
 

--- a/butterfree/load/processing/__init__.py
+++ b/butterfree/load/processing/__init__.py
@@ -1,0 +1,4 @@
+"""Pre Processing Components regarding Readers."""
+from butterfree.load.processing.json_transform import json_transform
+
+__all__ = ["json_transform"]

--- a/butterfree/load/processing/json_transform.py
+++ b/butterfree/load/processing/json_transform.py
@@ -1,0 +1,20 @@
+"""Json conversion for writers."""
+from pyspark.sql.dataframe import DataFrame
+from pyspark.sql.functions import struct, to_json
+
+
+def json_transform(dataframe: DataFrame):
+    """Filters DataFrame's rows using the given condition and value.
+
+    Args:
+        dataframe: Spark DataFrame.
+
+    Returns:
+        Converted dataframe.
+    """
+
+    return dataframe.select(
+        to_json(struct([dataframe[column] for column in dataframe.columns])).alias(
+            "value"
+        )
+    )

--- a/butterfree/load/processing/json_transform.py
+++ b/butterfree/load/processing/json_transform.py
@@ -12,7 +12,6 @@ def json_transform(dataframe: DataFrame):
     Returns:
         Converted dataframe.
     """
-
     return dataframe.select(
         to_json(struct([dataframe[column] for column in dataframe.columns])).alias(
             "value"

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -95,6 +95,7 @@ class HistoricalFeatureStoreWriter(Writer):
         validation_threshold: float = DEFAULT_VALIDATION_THRESHOLD,
         debug_mode: bool = False,
     ):
+        super().__init__()
         self.db_config = db_config or S3Config()
         self.database = database or environment.get_variable(
             "FEATURE_STORE_HISTORICAL_DATABASE"
@@ -119,6 +120,8 @@ class HistoricalFeatureStoreWriter(Writer):
 
         """
         dataframe = self._create_partitions(dataframe)
+
+        dataframe = self._apply_transformations(dataframe)
 
         if self.debug_mode:
             spark_client.create_temporary_view(

--- a/butterfree/load/writers/online_feature_store_writer.py
+++ b/butterfree/load/writers/online_feature_store_writer.py
@@ -71,6 +71,7 @@ class OnlineFeatureStoreWriter(Writer):
     __name__ = "Online Feature Store Writer"
 
     def __init__(self, db_config=None, debug_mode: bool = False, write_to_entity=False):
+        super().__init__()
         self.db_config = db_config or CassandraConfig()
         self.debug_mode = debug_mode
         self.write_to_entity = write_to_entity
@@ -165,6 +166,7 @@ class OnlineFeatureStoreWriter(Writer):
         table_name = feature_set.entity if self.write_to_entity else feature_set.name
 
         if dataframe.isStreaming:
+            dataframe = self._apply_transformations(dataframe)
             if self.debug_mode:
                 return self._write_in_debug_mode(
                     table_name=table_name,
@@ -181,6 +183,8 @@ class OnlineFeatureStoreWriter(Writer):
         latest_df = self.filter_latest(
             dataframe=dataframe, id_columns=feature_set.keys_columns
         )
+
+        latest_df = self._apply_transformations(latest_df)
 
         if self.debug_mode:
             return self._write_in_debug_mode(

--- a/butterfree/load/writers/writer.py
+++ b/butterfree/load/writers/writer.py
@@ -1,6 +1,8 @@
 """Writer entity."""
 
 from abc import ABC, abstractmethod
+from functools import reduce
+from typing import Callable
 
 from pyspark.sql.dataframe import DataFrame
 
@@ -15,6 +17,41 @@ class Writer(ABC):
         spark_client: client for spark connections with external services.
 
     """
+
+    def __init__(self):
+        self.transformations = []
+
+    def with_(self, transformer: Callable, *args, **kwargs):
+        """Define a new transformation for the Reader.
+
+        All the transformations are used when the method consume is called.
+
+        Args:
+            transformer: method that receives a dataframe and output a
+                dataframe.
+            *args: args for the transformer.
+            **kwargs: kwargs for the transformer.
+
+        Returns:
+            Reader object with new transformation
+
+        """
+        new_transformation = {
+            "transformer": transformer,
+            "args": args if args else (),
+            "kwargs": kwargs if kwargs else {},
+        }
+        self.transformations.append(new_transformation)
+        return self
+
+    def _apply_transformations(self, df: DataFrame) -> DataFrame:
+        return reduce(
+            lambda result_df, transformation: transformation["transformer"](
+                result_df, *transformation["args"], **transformation["kwargs"]
+            ),
+            self.transformations,
+            df,
+        )
 
     @abstractmethod
     def write(

--- a/butterfree/load/writers/writer.py
+++ b/butterfree/load/writers/writer.py
@@ -22,7 +22,7 @@ class Writer(ABC):
         self.transformations = []
 
     def with_(self, transformer: Callable, *args, **kwargs):
-        """Define a new transformation for the Reader.
+        """Define a new transformation for the Writer.
 
         All the transformations are used when the method consume is called.
 

--- a/tests/unit/butterfree/configs/db/conftest.py
+++ b/tests/unit/butterfree/configs/db/conftest.py
@@ -1,6 +1,6 @@
 from pytest import fixture
 
-from butterfree.configs.db import CassandraConfig, S3Config
+from butterfree.configs.db import CassandraConfig, KafkaConfig, S3Config
 
 
 @fixture
@@ -11,6 +11,13 @@ def cassandra_config(monkeypatch):
     monkeypatch.setenv("CASSANDRA_USERNAME", "test")
 
     return CassandraConfig()
+
+
+@fixture
+def kafka_config(monkeypatch):
+    monkeypatch.setenv("KAFKA_CONNECTION_STRING", "test")
+
+    return KafkaConfig()
 
 
 @fixture

--- a/tests/unit/butterfree/configs/db/test_kafka_config.py
+++ b/tests/unit/butterfree/configs/db/test_kafka_config.py
@@ -1,0 +1,104 @@
+import pytest
+
+from butterfree.configs.db import KafkaConfig
+
+
+class TestKafkaConfig:
+    def test_mode(self, kafka_config):
+        # expecting
+        default = "append"
+        assert kafka_config.mode == default
+
+        # given
+        kafka_config.mode = None
+        # then
+        assert kafka_config.mode == default
+
+    def test_mode_custom(self, kafka_config):
+        # given
+        mode = "overwrite"
+        kafka_config.mode = mode
+
+        # then
+        assert kafka_config.mode == mode
+
+    def test_format(self, kafka_config):
+        # expecting
+        default = "kafka"
+        assert kafka_config.format_ == default
+
+        # given
+        kafka_config.format_ = None
+        # then
+        assert kafka_config.format_ == default
+
+    def test_format_custom(self, kafka_config):
+        # given
+        format_ = "custom.quintoandar.kafka"
+        kafka_config.format_ = format_
+
+        # then
+        assert kafka_config.format_ == format_
+
+    def test_kafka_connection_string(self, kafka_config):
+        # expecting
+        default = "test"
+        assert kafka_config.kafka_connection_string == default
+
+    def test_kafka_connection_string_empty(self, kafka_config, mocker):
+        # given
+        mocker.patch("butterfree.configs.environment.get_variable", return_value=None)
+
+        with pytest.raises(ValueError, match="cannot be empty"):
+            kafka_config.kafka_connection_string = None
+
+    def test_kafka_connection_string_custom(self, kafka_config):
+        # given
+        kafka_connection_string = "butterfree"
+        kafka_config.kafka_connection_string = kafka_connection_string
+
+        # then
+        assert kafka_config.kafka_connection_string == kafka_connection_string
+
+    def test_stream_processing_time(self, kafka_config):
+        # expecting
+        default = "0 seconds"
+        assert kafka_config.stream_processing_time == default
+
+    def test_stream_processing_time_custom(self, kafka_config):
+        # given
+        value = "10 seconds"
+        kafka_config.stream_processing_time = value
+
+        # then
+        assert kafka_config.stream_processing_time == value
+
+    def test_stream_output_mode(self, kafka_config):
+        # expecting
+        default = "update"
+        assert kafka_config.stream_output_mode == default
+
+    def test_stream_output_mode_custom(self, kafka_config):
+        # given
+        value = "complete"
+        kafka_config.stream_output_mode = value
+
+        # then
+        assert kafka_config.stream_output_mode == value
+
+    def test_stream_checkpoint_path(self, kafka_config):
+        # expecting
+        default = None
+        assert kafka_config.stream_checkpoint_path == default
+
+    def test_stream_checkpoint_path_custom(self, kafka_config):
+        # given
+        value = "s3://path/to/checkpoint"
+        kafka_config.stream_checkpoint_path = value
+
+        # then
+        assert kafka_config.stream_checkpoint_path == value
+
+    def test_set_credentials_on_instantiation(self):
+        kafka_config = KafkaConfig(kafka_connection_string="topic")  # noqa: S106
+        assert kafka_config.kafka_connection_string == "topic"

--- a/tests/unit/butterfree/configs/db/test_kafka_config.py
+++ b/tests/unit/butterfree/configs/db/test_kafka_config.py
@@ -42,7 +42,7 @@ class TestKafkaConfig:
 
     def test_kafka_connection_string(self, kafka_config):
         # expecting
-        default = "test"
+        default = "test_host:1234,test_host2:1234"
         assert kafka_config.kafka_connection_string == default
 
     def test_kafka_connection_string_empty(self, kafka_config, mocker):

--- a/tests/unit/butterfree/load/conftest.py
+++ b/tests/unit/butterfree/load/conftest.py
@@ -211,3 +211,27 @@ def expected_schema():
             "primary_key": False,
         },
     ]
+
+
+@fixture
+def historical_feature_set_dataframe_json(spark_context, spark_session):
+    data = [
+        '{"value":"{\\"feature\\":120,\\"id\\":1,\\"timestamp\\":\\"2020-02-01\\",\\"year\\":2020,'
+        '\\"month\\":2,\\"day\\":1}"}',
+        '{"value":"{\\"feature\\":110,\\"id\\":1,\\"timestamp\\":\\"2020-01-15\\",\\"year\\":2020,'
+        '\\"month\\":1,\\"day\\":15}"}',
+        '{"value":"{\\"feature\\":100,\\"id\\":1,\\"timestamp\\":\\"2019-12-31\\",\\"year\\":2019,'
+        '\\"month\\":12,\\"day\\":31}"}',
+        '{"value":"{\\"feature\\":200,\\"id\\":2,\\"timestamp\\":\\"2019-12-31\\",\\"year\\":2019,'
+        '\\"month\\":12,\\"day\\":31}"}',
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))
+
+
+@fixture
+def online_feature_set_dataframe_json(spark_context, spark_session):
+    data = [
+        '{"value":"{\\"feature\\":120,\\"id\\":1,\\"timestamp\\":\\"2020-02-01\\"}"}',
+        '{"value":"{\\"feature\\":200,\\"id\\":2,\\"timestamp\\":\\"2019-12-31\\"}"}',
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))

--- a/tests/unit/butterfree/load/conftest.py
+++ b/tests/unit/butterfree/load/conftest.py
@@ -216,14 +216,14 @@ def expected_schema():
 @fixture
 def historical_feature_set_dataframe_json(spark_context, spark_session):
     data = [
-        '{"value":"{\\"feature\\":120,\\"id\\":1,\\"timestamp\\":\\"2020-02-01\\",\\"year\\":2020,'
-        '\\"month\\":2,\\"day\\":1}"}',
-        '{"value":"{\\"feature\\":110,\\"id\\":1,\\"timestamp\\":\\"2020-01-15\\",\\"year\\":2020,'
-        '\\"month\\":1,\\"day\\":15}"}',
-        '{"value":"{\\"feature\\":100,\\"id\\":1,\\"timestamp\\":\\"2019-12-31\\",\\"year\\":2019,'
-        '\\"month\\":12,\\"day\\":31}"}',
-        '{"value":"{\\"feature\\":200,\\"id\\":2,\\"timestamp\\":\\"2019-12-31\\",\\"year\\":2019,'
-        '\\"month\\":12,\\"day\\":31}"}',
+        '{"value":"{\\"feature\\":120,\\"id\\":1,\\"timestamp\\":\\"2020-02-01\\",'
+        '\\"year\\":2020,\\"month\\":2,\\"day\\":1}"}',
+        '{"value":"{\\"feature\\":110,\\"id\\":1,\\"timestamp\\":\\"2020-01-15\\",'
+        '\\"year\\":2020,\\"month\\":1,\\"day\\":15}"}',
+        '{"value":"{\\"feature\\":100,\\"id\\":1,\\"timestamp\\":\\"2019-12-31\\",'
+        '\\"year\\":2019,\\"month\\":12,\\"day\\":31}"}',
+        '{"value":"{\\"feature\\":200,\\"id\\":2,\\"timestamp\\":\\"2019-12-31\\",'
+        '\\"year\\":2019,\\"month\\":12,\\"day\\":31}"}',
     ]
     return spark_session.read.json(spark_context.parallelize(data, 1))
 

--- a/tests/unit/butterfree/load/processing/conftest.py
+++ b/tests/unit/butterfree/load/processing/conftest.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 

--- a/tests/unit/butterfree/load/processing/conftest.py
+++ b/tests/unit/butterfree/load/processing/conftest.py
@@ -1,0 +1,27 @@
+import json
+
+import pytest
+
+
+@pytest.fixture()
+def input_df(spark_context, spark_session):
+    data = [
+        {"id": 1, "ts": "2016-04-11 11:31:11"},
+        {"id": 1, "ts": "2016-04-11 11:44:12"},
+        {"id": 1, "ts": "2016-04-11 11:46:24"},
+        {"id": 1, "ts": "2016-04-11 12:03:21"},
+        {"id": 1, "ts": "2016-04-11 13:46:24"},
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))
+
+
+@pytest.fixture()
+def json_df(spark_context, spark_session):
+    data = [
+        '{"value":"{\\"id\\":1,\\"ts\\":\\"2016-04-11 11:31:11\\"}"}',
+        '{"value":"{\\"id\\":1,\\"ts\\":\\"2016-04-11 11:44:12\\"}"}',
+        '{"value":"{\\"id\\":1,\\"ts\\":\\"2016-04-11 11:46:24\\"}"}',
+        '{"value":"{\\"id\\":1,\\"ts\\":\\"2016-04-11 12:03:21\\"}"}',
+        '{"value":"{\\"id\\":1,\\"ts\\":\\"2016-04-11 13:46:24\\"}"}',
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))

--- a/tests/unit/butterfree/load/processing/test_json_transform.py
+++ b/tests/unit/butterfree/load/processing/test_json_transform.py
@@ -1,0 +1,11 @@
+from butterfree.load.processing import json_transform
+
+
+class TestJsonTransform:
+    def test_json_transformation(
+        self, input_df, json_df,
+    ):
+        result_df = json_transform(dataframe=input_df)
+
+        # assert
+        assert sorted(result_df.collect()) == sorted(json_df.collect())

--- a/tests/unit/butterfree/load/writers/test_online_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_online_feature_store_writer.py
@@ -5,7 +5,7 @@ from pyspark.sql import DataFrame
 from pyspark.sql.streaming import StreamingQuery
 
 from butterfree.clients import SparkClient
-from butterfree.configs.db import CassandraConfig, KafkaConfig
+from butterfree.configs.db import CassandraConfig
 from butterfree.load.processing import json_transform
 from butterfree.load.writers import OnlineFeatureStoreWriter
 from butterfree.testing.dataframe import assert_dataframe_equality


### PR DESCRIPTION
## Why? :open_book:
We'd like to enable Butterfree to write to Kafka topics.

## What? :wrench:
Added a new ```KafkaConfig``` and possibility to define transformations within the ```Writer``` scope.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
