### PR TITLE
Fix unit-test message about black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ style-check:
 	@echo "Code Style"
 	@echo "=========="
 	@echo ""
-	@python -m black --check -t py36 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" . && echo "\n\nSuccess" || (echo "\n\nFailure\n\nRun \"make black\" to apply style formatting to your code"; exit 1)
+	@python -m black --check -t py36 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" . && echo "\n\nSuccess" || (echo "\n\nFailure\n\nYou need to run \"make apply-style\" to apply style formatting to your code"; exit 1)
 
 .PHONY: quality-check
 ## run code quality checks with flake8


### PR DESCRIPTION
## Why? :open_book:
When the black fails during the test workflow in GitHub actions, a wrong informative message was being shown

## What? :wrench:
- change `make black` to `make apply-style` in the message, according to the Makefile.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Via test workflow

## Checklist
- [ ] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [ ] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

