### PR TITLE
Fix Butterfree's workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       run: make package
 
     - name: Get version
-      run: echo ::set-env name=version::$(grep __version__ setup.py | head -1 | cut -d \" -f2 | cut -d \' -f2)
+      run: echo "version=$(grep __version__ setup.py | head -1 | cut -d \" -f2 | cut -d \' -f2)" >> $GITHUB_ENV
 
     - name: Create release
       uses: actions/create-release@v1


### PR DESCRIPTION
## Why? :open_book:
This PR intends to fix a issue regarding github actions workflow, as it can be seen [here](https://github.com/quintoandar/butterfree/runs/1444438769?check_suite_focus=true).

## What? :wrench:
Updated Butterfree's workflow, due to the following errors messages:
```bash
Error: Unable to process command '::set-env name=version::1.1.0' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```