### PR TITLE
[MLOP-590] Adapt KafkaConfig to receive a custom topic name

### DIFF
--- a/butterfree/configs/db/kafka_config.py
+++ b/butterfree/configs/db/kafka_config.py
@@ -9,6 +9,7 @@ class KafkaConfig(AbstractWriteConfig):
     """Configuration for Spark to connect to Kafka.
 
     Attributes:
+        kafka_topic: string with kafka topic name.
         kafka_connection_string: string with hosts and ports to connect.
         mode: write mode for Spark.
         format_: write format for Spark.
@@ -24,6 +25,7 @@ class KafkaConfig(AbstractWriteConfig):
 
     def __init__(
         self,
+        kafka_topic: str = None,
         kafka_connection_string: str = None,
         mode: str = None,
         format_: str = None,
@@ -31,6 +33,7 @@ class KafkaConfig(AbstractWriteConfig):
         stream_output_mode: str = None,
         stream_checkpoint_path: str = None,
     ):
+        self.kafka_topic = kafka_topic
         self.kafka_connection_string = kafka_connection_string
         self.mode = mode
         self.format_ = format_
@@ -39,8 +42,17 @@ class KafkaConfig(AbstractWriteConfig):
         self.stream_checkpoint_path = stream_checkpoint_path
 
     @property
+    def kafka_topic(self) -> str:
+        """Kafka topic name."""
+        return self.__kafka_topic
+
+    @kafka_topic.setter
+    def kafka_topic(self, value: str):
+        self.__kafka_topic = value
+
+    @property
     def kafka_connection_string(self) -> str:
-        """Username used in connection to Cassandra DB."""
+        """Kafka connection string with hosts and ports to connect."""
         return self.__kafka_connection_string
 
     @kafka_connection_string.setter
@@ -113,7 +125,7 @@ class KafkaConfig(AbstractWriteConfig):
 
         """
         return {
-            "topic": topic,
+            "topic": self.kafka_topic or topic,
             "kafka.bootstrap.servers": self.kafka_connection_string,
         }
 

--- a/butterfree/load/writers/online_feature_store_writer.py
+++ b/butterfree/load/writers/online_feature_store_writer.py
@@ -131,7 +131,7 @@ class OnlineFeatureStoreWriter(Writer):
             checkpoint_path=checkpoint_path,
             format_=self.db_config.format_,
             mode=self.db_config.mode,
-            **self.db_config.get_options(table=table_name),
+            **self.db_config.get_options(table_name),
         )
         return streaming_handler
 
@@ -195,7 +195,7 @@ class OnlineFeatureStoreWriter(Writer):
             dataframe=latest_df,
             format_=self.db_config.format_,
             mode=self.db_config.mode,
-            **self.db_config.get_options(table=table_name),
+            **self.db_config.get_options(table_name),
         )
 
     def validate(self, feature_set: FeatureSet, dataframe, spark_client: SparkClient):

--- a/tests/unit/butterfree/configs/db/test_kafka_config.py
+++ b/tests/unit/butterfree/configs/db/test_kafka_config.py
@@ -100,5 +100,8 @@ class TestKafkaConfig:
         assert kafka_config.stream_checkpoint_path == value
 
     def test_set_credentials_on_instantiation(self):
-        kafka_config = KafkaConfig(kafka_connection_string="topic")  # noqa: S106
-        assert kafka_config.kafka_connection_string == "topic"
+        kafka_config = KafkaConfig(  # noqa: S106
+            kafka_topic="kafka_topic", kafka_connection_string="test_host:1234"
+        )
+        assert kafka_config.kafka_topic == "kafka_topic"
+        assert kafka_config.kafka_connection_string == "test_host:1234"

--- a/tests/unit/butterfree/load/writers/test_online_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_online_feature_store_writer.py
@@ -5,7 +5,7 @@ from pyspark.sql import DataFrame
 from pyspark.sql.streaming import StreamingQuery
 
 from butterfree.clients import SparkClient
-from butterfree.configs.db import CassandraConfig
+from butterfree.configs.db import CassandraConfig, KafkaConfig
 from butterfree.load.processing import json_transform
 from butterfree.load.writers import OnlineFeatureStoreWriter
 from butterfree.testing.dataframe import assert_dataframe_equality
@@ -255,4 +255,70 @@ class TestOnlineFeatureStoreWriter:
         assert all(
             item in spark_client.write_dataframe.call_args[1].items()
             for item in writer.db_config.get_options(table=feature_set.name).items()
+        )
+
+    def test_write_with_kafka_config(
+        self,
+        feature_set_dataframe,
+        online_feature_set_dataframe_json,
+        mocker,
+        feature_set,
+    ):
+        # with
+        spark_client = mocker.stub("spark_client")
+        spark_client.write_dataframe = mocker.stub("write_dataframe")
+        kafka_config = KafkaConfig()
+        writer = OnlineFeatureStoreWriter(kafka_config).with_(json_transform)
+
+        # when
+        writer.write(feature_set, feature_set_dataframe, spark_client)
+
+        assert sorted(online_feature_set_dataframe_json.collect()) == sorted(
+            spark_client.write_dataframe.call_args[1]["dataframe"].collect()
+        )
+        assert (
+            writer.db_config.mode == spark_client.write_dataframe.call_args[1]["mode"]
+        )
+        assert (
+            writer.db_config.format_
+            == spark_client.write_dataframe.call_args[1]["format_"]
+        )
+        # assert if all additional options got from db_config
+        # are in the called args in write_dataframe
+        assert all(
+            item in spark_client.write_dataframe.call_args[1].items()
+            for item in writer.db_config.get_options(topic=feature_set.name).items()
+        )
+
+    def test_write_with_custom_kafka_config(
+        self,
+        feature_set_dataframe,
+        online_feature_set_dataframe_json,
+        mocker,
+        feature_set,
+    ):
+        # with
+        spark_client = mocker.stub("spark_client")
+        spark_client.write_dataframe = mocker.stub("write_dataframe")
+        kafka_config = KafkaConfig(kafka_topic="custom_topic")
+        writer = OnlineFeatureStoreWriter(kafka_config).with_(json_transform)
+
+        # when
+        writer.write(feature_set, feature_set_dataframe, spark_client)
+
+        assert sorted(online_feature_set_dataframe_json.collect()) == sorted(
+            spark_client.write_dataframe.call_args[1]["dataframe"].collect()
+        )
+        assert (
+            writer.db_config.mode == spark_client.write_dataframe.call_args[1]["mode"]
+        )
+        assert (
+            writer.db_config.format_
+            == spark_client.write_dataframe.call_args[1]["format_"]
+        )
+        # assert if all additional options got from db_config
+        # are in the called args in write_dataframe
+        assert all(
+            item in spark_client.write_dataframe.call_args[1].items()
+            for item in writer.db_config.get_options(topic="custom_topic").items()
         )

--- a/tests/unit/butterfree/load/writers/test_online_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_online_feature_store_writer.py
@@ -273,18 +273,6 @@ class TestOnlineFeatureStoreWriter:
         # when
         writer.write(feature_set, feature_set_dataframe, spark_client)
 
-        assert sorted(online_feature_set_dataframe_json.collect()) == sorted(
-            spark_client.write_dataframe.call_args[1]["dataframe"].collect()
-        )
-        assert (
-            writer.db_config.mode == spark_client.write_dataframe.call_args[1]["mode"]
-        )
-        assert (
-            writer.db_config.format_
-            == spark_client.write_dataframe.call_args[1]["format_"]
-        )
-        # assert if all additional options got from db_config
-        # are in the called args in write_dataframe
         assert all(
             item in spark_client.write_dataframe.call_args[1].items()
             for item in writer.db_config.get_options(topic=feature_set.name).items()
@@ -300,25 +288,17 @@ class TestOnlineFeatureStoreWriter:
         # with
         spark_client = mocker.stub("spark_client")
         spark_client.write_dataframe = mocker.stub("write_dataframe")
-        kafka_config = KafkaConfig(kafka_topic="custom_topic")
-        writer = OnlineFeatureStoreWriter(kafka_config).with_(json_transform)
+        custom_kafka_config = KafkaConfig(kafka_topic="custom_topic")
+        custom_writer = OnlineFeatureStoreWriter(custom_kafka_config).with_(
+            json_transform
+        )
 
         # when
-        writer.write(feature_set, feature_set_dataframe, spark_client)
+        custom_writer.write(feature_set, feature_set_dataframe, spark_client)
 
-        assert sorted(online_feature_set_dataframe_json.collect()) == sorted(
-            spark_client.write_dataframe.call_args[1]["dataframe"].collect()
-        )
-        assert (
-            writer.db_config.mode == spark_client.write_dataframe.call_args[1]["mode"]
-        )
-        assert (
-            writer.db_config.format_
-            == spark_client.write_dataframe.call_args[1]["format_"]
-        )
-        # assert if all additional options got from db_config
-        # are in the called args in write_dataframe
         assert all(
             item in spark_client.write_dataframe.call_args[1].items()
-            for item in writer.db_config.get_options(topic="custom_topic").items()
+            for item in custom_writer.db_config.get_options(
+                topic="custom_topic"
+            ).items()
         )


### PR DESCRIPTION
## Why? :open_book:
We'd like to enable our users to select a custom kafka topic name, in order to write to a given Kafka topic.

## What? :wrench:
Added a new parameter, ```kafka_topic```, within ```KafkaConfig```. It's an optional parameter and if the user don't use it, then we'll have Butterfree's default behavior (it'll look for a topic with the following names: ```feature_set.name``` or ```feature_set.entity```).

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
