### PR TITLE
FIX Read the Docs build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,6 @@ Or after listing `butterfree` in your `requirements.txt` file:
 pip install -r requirements.txt
 ```
 
-You may also have access to our preview build (unstable) by installing from `staging` branch:
-
-```bash
-pip install git+https://github.com/quintoandar/butterfree.git@staging
-```
-
 ## License
 [Apache License 2.0](https://github.com/quintoandar/butterfree/blob/staging/LICENSE)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2
-cmake=3.18.4.post1
+cmake==3.18.4.post1
 h3==3.4.3
 pyarrow==0.15.1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2
-cmake==3.13.3
+cmake=3.18.4.post1
 h3==3.4.3
 pyarrow==0.15.1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2
-cmake==3.18.4.post1
+cmake==3.18.4
 h3==3.7.0
 pyarrow==0.15.1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,6 @@ sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2
 cmake==3.18.4.post1
-h3==3.4.3
+h3==3.7.0
 pyarrow==0.15.1
 

--- a/docs/source/getstart.md
+++ b/docs/source/getstart.md
@@ -14,12 +14,6 @@ Or after listing `butterfree` in your `requirements.txt` file:
 pip install -r requirements.txt
 ```
 
-You may also have access to our preview build (unstable) by installing from `staging` branch:
-
-```bash
-pip install git+https://github.com/quintoandar/butterfree.git@staging
-```
-
 ## Discovering Butterfree
 
 Welcome to **Discovering Butterfree** tutorial series! Click on the following links to open the tutorials:

--- a/docs/source/stream.md
+++ b/docs/source/stream.md
@@ -10,7 +10,7 @@ Streaming feature sets are the ones that have at least one streaming source of d
 
 Using readers in streaming mode will make use of Spark's `readStream` API instead of the normal `read`. That means it will produce a stream dataframe (`df.isStreaming == True`) instead of a normal Spark's dataframe.
 
-The currently supported readers in stream mode are `FileReader` and `KafkaReader`. For more information about the specifications read their docstrings, [here](https://github.com/quintoandar/butterfree/blob/staging/butterfree/core/extract/readers/file_reader.py#L10) and [here](https://github.com/quintoandar/butterfree/blob/staging/butterfree/core/extract/readers/kafka_reader.py#L14) respectively. 
+The currently supported readers in stream mode are `FileReader` and `KafkaReader`. For more information about the specifications read their docstrings, [here](https://github.com/quintoandar/butterfree/blob/master/butterfree/extract/readers/file_reader.py#L10) and [here](https://github.com/quintoandar/butterfree/blob/master/butterfree/extract/readers/kafka_reader.py#L12) respectively. 
 
 ## Online Feature Store Writer
 `OnlineFeatureStoreWriter` is currently the only writer that supports streaming dataframes. It will write, in real time, and upserts to Cassandra. It uses `df.writeStream` and `foreachBatch` Spark functionality to do that. You can read more about `forachBatch` [here](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#using-foreach-and-foreachbatch).

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-cmake==3.18.4.post1
+cmake==3.18.4
 h3==3.7.0
 pyarrow==0.15.1
 jupyter==1.0.0

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
-cmake==3.13.3
-h3==3.4.3
+cmake==3.18.4.post1
+h3==3.7.0
 pyarrow==0.15.1
 jupyter==1.0.0
 twine==3.1.1


### PR DESCRIPTION
## Why? :open_book:
Read the Docs was unable to build the documentation because of the h3 version. I took the opportunity to update the documentation as well.

## What? :wrench:
- README
- Docs
- Requirements

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How everything was tested? :straight_ruler:
You can see the build [here](https://readthedocs.org/projects/butterfree/builds/12473033/)

## Checklist
- [x] I have made corresponding changes to the documentation;
