### PR TITLE
[HOTFIX] Add both cache and count back to Butterfree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@ All notable changes to this project will be documented in this file.
 
 Preferably use **Added**, **Changed**, **Removed** and **Fixed** topics in each release or unreleased log for a better organization.
 
-## [1.1.1](https://github.com/quintoandar/butterfree/releases/tag/1.2.0)
+## [1.1.2](https://github.com/quintoandar/butterfree/releases/tag/1.1.2)
+### Fixed
+* [HOTFIX] Add both cache and count back to Butterfree ([#274](https://github.com/quintoandar/butterfree/pull/274))
+* [MLOP-606] Change docker image in Github Actions Pipeline ([#275](https://github.com/quintoandar/butterfree/pull/275))
+* FIX Read the Docs build ([#272](https://github.com/quintoandar/butterfree/pull/272))
+* [BUG] Fix style ([#271](https://github.com/quintoandar/butterfree/pull/271))
+* [MLOP-594] Remove from_column in some transforms ([#270](https://github.com/quintoandar/butterfree/pull/270))
+* [MLOP-536] Rename S3 config to Metastore config ([#269](https://github.com/quintoandar/butterfree/pull/269))
+
+## [1.1.1](https://github.com/quintoandar/butterfree/releases/tag/1.1.1)
 ### Added
 * [MLOP-590] Adapt KafkaConfig to receive a custom topic name ([#266](https://github.com/quintoandar/butterfree/pull/266))
 

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -75,4 +75,7 @@ class Source:
 
         dataframe = client.sql(self.query)
 
+        if not dataframe.isStreaming:
+            dataframe.cache().count()
+
         return dataframe

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -539,5 +539,6 @@ class AggregatedFeatureSet(FeatureSet):
         output_df = output_df.select(*self.columns).replace(float("nan"), None)
         if not output_df.isStreaming:
             output_df = self._filter_duplicated_rows(output_df)
+            output_df.cache().count()
 
         return output_df

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -411,5 +411,6 @@ class FeatureSet:
 
         if not output_df.isStreaming:
             output_df = self._filter_duplicated_rows(output_df)
+            output_df.cache().count()
 
         return output_df

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:

--- a/tests/unit/butterfree/extract/test_source.py
+++ b/tests/unit/butterfree/extract/test_source.py
@@ -20,3 +20,21 @@ class TestSource:
         result_df = source_selector.construct(spark_client)
 
         assert result_df.collect() == target_df.collect()
+
+    def test_is_cached(self, mocker, target_df):
+        # given
+        spark_client = SparkClient()
+
+        reader_id = "a_source"
+        reader = mocker.stub(reader_id)
+        reader.build = mocker.stub("build")
+        reader.build.side_effect = target_df.createOrReplaceTempView(reader_id)
+
+        # when
+        source_selector = Source(
+            readers=[reader], query=f"select * from {reader_id}",  # noqa
+        )
+
+        result_df = source_selector.construct(spark_client)
+
+        assert result_df.is_cached

--- a/tests/unit/butterfree/transform/test_feature_set.py
+++ b/tests/unit/butterfree/transform/test_feature_set.py
@@ -215,6 +215,7 @@ class TestFeatureSet:
             + feature_divide.get_output_columns()
         )
         assert_dataframe_equality(result_df, feature_set_dataframe)
+        assert result_df.is_cached
 
     def test_construct_invalid_df(
         self, key_id, timestamp_c, feature_add, feature_divide


### PR DESCRIPTION
## Why? :open_book:
It was necessary to add ```cache``` and ```count``` back to Butterfree, since some odd behaviour was observed after their removal.

## What? :wrench:
Added both ```cache``` and ```count``` back.