### PR TITLE
[MLOP-606] Change docker image in Github Actions Pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref == 'refs/heads/master' || contains(github.ref, 'hotfix/')
 
     runs-on: ubuntu-16.04
-    container: rafaelleinio/docker-java-python
+    container: quintoandar/python-3-7-java
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   Pipeline:
     runs-on: ubuntu-16.04
-    container: rafaelleinio/docker-java-python
+    container: quintoandar/python-3-7-java
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Why? :open_book:
Today we are using a docker image on the docker hub straight from another account, and the DE team uploaded this image to QuintoAndar's account. So we need to change the image in the Github Actions pipeline.

## What? :wrench:
- Github Actions pipelines

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.