### PR TITLE
Keep milliseconds when using 'from_ms' argument in timestamp feature

### DIFF
--- a/butterfree/transform/features/timestamp_feature.py
+++ b/butterfree/transform/features/timestamp_feature.py
@@ -1,6 +1,6 @@
 """TimestampFeature entity."""
 from pyspark.sql import DataFrame
-from pyspark.sql.functions import from_unixtime, to_timestamp
+from pyspark.sql.functions import to_timestamp
 
 from butterfree.constants import DataType
 from butterfree.constants.columns import TIMESTAMP_COLUMN

--- a/butterfree/transform/features/timestamp_feature.py
+++ b/butterfree/transform/features/timestamp_feature.py
@@ -65,13 +65,12 @@ class TimestampFeature(Feature):
         """
         column_name = self.from_column if self.from_column else self.name
 
+        ts_column = dataframe[column_name]
         if self.from_ms:
-            dataframe = dataframe.withColumn(
-                column_name, to_timestamp(dataframe[column_name] / 1000)
-            )
-        if self.mask:
-            dataframe = dataframe.withColumn(
-                column_name, to_timestamp(dataframe[column_name], self.mask)
-            )
+            ts_column = ts_column / 1000
+
+        dataframe = dataframe.withColumn(
+            column_name, to_timestamp(ts_column, self.mask)
+        )
 
         return super().transform(dataframe)

--- a/butterfree/transform/features/timestamp_feature.py
+++ b/butterfree/transform/features/timestamp_feature.py
@@ -67,7 +67,7 @@ class TimestampFeature(Feature):
 
         if self.from_ms:
             dataframe = dataframe.withColumn(
-                column_name, from_unixtime(dataframe[column_name] / 1000.0)
+                column_name, to_timestamp(dataframe[column_name] / 1000)
             )
         if self.mask:
             dataframe = dataframe.withColumn(

--- a/tests/unit/butterfree/transform/features/conftest.py
+++ b/tests/unit/butterfree/transform/features/conftest.py
@@ -18,8 +18,8 @@ def feature_set_dataframe(spark_context, spark_session):
 @fixture
 def feature_set_dataframe_ms_from_column(spark_context, spark_session):
     data = [
-        {"id": 1, "ts": 1581542311000, "feature": 100},
-        {"id": 2, "ts": 1581542322000, "feature": 200},
+        {"id": 1, "ts": 1581542311112, "feature": 100},
+        {"id": 2, "ts": 1581542322223, "feature": 200},
     ]
     return spark_session.read.json(spark_context.parallelize(data, 1))
 
@@ -27,8 +27,17 @@ def feature_set_dataframe_ms_from_column(spark_context, spark_session):
 @fixture
 def feature_set_dataframe_ms(spark_context, spark_session):
     data = [
-        {"id": 1, TIMESTAMP_COLUMN: 1581542311000, "feature": 100},
-        {"id": 2, TIMESTAMP_COLUMN: 1581542322000, "feature": 200},
+        {"id": 1, TIMESTAMP_COLUMN: 1581542311112, "feature": 100},
+        {"id": 2, TIMESTAMP_COLUMN: 1581542322223, "feature": 200},
+    ]
+    return spark_session.read.json(spark_context.parallelize(data, 1))
+
+
+@fixture
+def feature_set_dataframe_small_time_diff(spark_context, spark_session):
+    data = [
+        {"id": 1, TIMESTAMP_COLUMN: 1581542311001, "feature": 100},
+        {"id": 2, TIMESTAMP_COLUMN: 1581542311002, "feature": 200},
     ]
     return spark_session.read.json(spark_context.parallelize(data, 1))
 

--- a/tests/unit/butterfree/transform/features/test_timestamp_feature.py
+++ b/tests/unit/butterfree/transform/features/test_timestamp_feature.py
@@ -32,8 +32,8 @@ class TestTimestampFeature:
 
         df = df.withColumn("timestamp", df["timestamp"].cast(StringType())).collect()
 
-        assert df[0]["timestamp"] == "2020-02-12 21:18:31"
-        assert df[1]["timestamp"] == "2020-02-12 21:18:42"
+        assert df[0]["timestamp"] == "2020-02-12 21:18:31.112"
+        assert df[1]["timestamp"] == "2020-02-12 21:18:42.223"
 
     def test_transform_ms(self, feature_set_dataframe_ms):
 
@@ -43,8 +43,22 @@ class TestTimestampFeature:
 
         df = df.withColumn("timestamp", df["timestamp"].cast(StringType())).collect()
 
-        assert df[0]["timestamp"] == "2020-02-12 21:18:31"
-        assert df[1]["timestamp"] == "2020-02-12 21:18:42"
+        assert df[0]["timestamp"] == "2020-02-12 21:18:31.112"
+        assert df[1]["timestamp"] == "2020-02-12 21:18:42.223"
+
+    def test_transform_ms_from_column_small_time_diff(
+        self, feature_set_dataframe_small_time_diff
+    ):
+
+        test_key = TimestampFeature(from_ms=True)
+
+        df = test_key.transform(feature_set_dataframe_small_time_diff).orderBy(
+            "timestamp"
+        )
+
+        df = df.withColumn("timestamp", df["timestamp"].cast(StringType())).collect()
+
+        assert df[0]["timestamp"] != df[1]["timestamp"]
 
     def test_transform_mask(self, feature_set_dataframe_date):
 


### PR DESCRIPTION
## Why? :open_book:

When creating historical features we want to have something like `(timestamp, entity_id)` as unique values. However if our source has entries in milliseconds, currently butterfree only store the timestamp within a second precision. This means that two entries in our source with same `id` in the same second(but in different millisecond) will have the same `(timestamp, entity_id)`. This PR aims to address this problem.


## What? :wrench:

Keep milliseconds when using 'from_ms' argument in timestamp feature in the `TimestampFeature`.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:

I added a unit test covering the case that needed to be addressed, and adapted other tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
