### PR TITLE
[BUG] Fix Staging GithubActions Pipeline

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -48,4 +48,4 @@ jobs:
       env:
         PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run:  PYTHONPATH=./pip/deps python -m twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD --verbose ./dist/p/*
+      run:  PYTHONPATH=./pip/deps python -m twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD --verbose ./dist/p/butterfree-${{ env.version }}-py3-none-any.whl


### PR DESCRIPTION
## Why? :open_book:
The current configuration of the pipeline did not work because it does not change the name of the package to add to PyPI.

## What? :wrench:
- Staging Pipeline


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

![image](https://user-images.githubusercontent.com/44944954/107276693-29f89c80-6a32-11eb-8087-b71b7fbaf773.png)
