### PR TITLE
Change trigger for pipeline staging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,8 +1,8 @@
 name: "Publish Dev Package"
 on:
   push:
-    branches:
-      - staging
+    paths:
+      - 'setup.py'
 
 
 jobs:
@@ -19,12 +19,10 @@ jobs:
       run: make ci-install
 
     - name: Get version
-      run: echo "version=$(grep __version__ setup.py | head -1 | cut -d \" -f2 | cut -d \' -f2 ).dev$(git rev-parse --short "$GITHUB_SHA")" >> $GITHUB_ENV
+      run: echo "version=$(grep __version__ setup.py | head -1 | cut -d \" -f2 | cut -d \' -f2 ) >> $GITHUB_ENV
 
     - name: Build package
-      run: |
-        make change-version NEW_VERSION="${{ env.version }}"
-        make package
+      run: make package
 
     - name: Create release
       uses: actions/create-release@v1

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -19,7 +19,7 @@ jobs:
       run: make ci-install
 
     - name: Get version
-      run: echo "version=$(grep __version__ setup.py | head -1 | cut -d \" -f2 | cut -d \' -f2 ) >> $GITHUB_ENV
+      run: echo "version=$(grep __version__ setup.py | head -1 | cut -d \" -f2 | cut -d \' -f2 )" >> $GITHUB_ENV
 
     - name: Build package
       run: make package


### PR DESCRIPTION
## Why? :open_book:
We had an error in the staging pipeline and found that the form we defined for the development version is not valid. So, we changed our trigger strategy.

> Many build tools integrate with distributed version control systems like Git and Mercurial in order to add an identifying hash to the version identifier. As hashes cannot be ordered reliably such versions are not permitted in the public version field.

If we need to create a package based on the staging branch we will have to change the version to this <version> .devN pattern. This will generate a pre-release and package in PyPI.

## What? :wrench:
- GithubActions - Staging

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

