### PR TITLE
Allow slide selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ checks: style-check quality-check type-check
 ## fix stylistic errors with black
 apply-style:
 	@python -m black -t py36 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" .
-	@python -m isort -rc butterfree/ tests/
+	@python -m isort -rc --atomic butterfree/ tests/
 
 .PHONY: clean
 ## clean unused artifacts

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -301,7 +301,9 @@ class AggregatedFeatureSet(FeatureSet):
 
         return self
 
-    def with_windows(self, definitions: List[str], slide: str = None) -> "AggregatedFeatureSet":
+    def with_windows(
+        self, definitions: List[str], slide: str = None
+    ) -> "AggregatedFeatureSet":
         """Create a list with windows defined."""
         self._windows = [
             Window(

--- a/butterfree/transform/utils/window_spec.py
+++ b/butterfree/transform/utils/window_spec.py
@@ -61,6 +61,7 @@ class Window:
 
     Use the static methods in :class:`Window` to create a :class:`WindowSpec`.
     """
+
     DEFAULT_SLIDE_DURATION: str = "1 day"
 
     def __init__(

--- a/butterfree/transform/utils/window_spec.py
+++ b/butterfree/transform/utils/window_spec.py
@@ -61,8 +61,7 @@ class Window:
 
     Use the static methods in :class:`Window` to create a :class:`WindowSpec`.
     """
-
-    SLIDE_DURATION: str = "1 day"
+    DEFAULT_SLIDE_DURATION: str = "1 day"
 
     def __init__(
         self,
@@ -70,10 +69,12 @@ class Window:
         partition_by: Optional[Union[Column, str, List[str]]] = None,
         order_by: Optional[Union[Column, str]] = None,
         mode: str = None,
+        slide: str = None,
     ):
         self.partition_by = partition_by
         self.order_by = order_by or TIMESTAMP_COLUMN
         self.frame_boundaries = FrameBoundaries(mode, window_definition)
+        self.slide = slide or self.DEFAULT_SLIDE_DURATION
 
     def get_name(self) -> str:
         """Return window suffix name based on passed criteria."""
@@ -89,15 +90,10 @@ class Window:
     def get(self) -> Any:
         """Defines a common window to be used both in time and rows windows."""
         if self.frame_boundaries.mode == "rolling_windows":
-            if int(self.frame_boundaries.window_definition.split()[0]) <= 0:
-                raise KeyError(
-                    f"{self.frame_boundaries.window_definition} "
-                    f"have negative element."
-                )
             return functions.window(
                 TIMESTAMP_COLUMN,
                 self.frame_boundaries.window_definition,
-                slideDuration=self.SLIDE_DURATION,
+                slideDuration=self.slide,
             )
         elif self.order_by == TIMESTAMP_COLUMN:
             w = sql.Window.partitionBy(self.partition_by).orderBy(  # type: ignore

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev0"
+__version__ = "1.2.0.dev1"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:

--- a/tests/unit/butterfree/transform/conftest.py
+++ b/tests/unit/butterfree/transform/conftest.py
@@ -6,7 +6,6 @@ from pytest import fixture
 
 from butterfree.constants import DataType
 from butterfree.constants.columns import TIMESTAMP_COLUMN
-<<<<<<< HEAD
 from butterfree.transform import FeatureSet
 from butterfree.transform.aggregated_feature_set import AggregatedFeatureSet
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
@@ -14,11 +13,6 @@ from butterfree.transform.transformations import (
     AggregatedTransform,
     SparkFunctionTransform,
 )
-=======
-from butterfree.transform.aggregated_feature_set import AggregatedFeatureSet
-from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
-from butterfree.transform.transformations import AggregatedTransform
->>>>>>> style compliant
 from butterfree.transform.utils import Function
 
 
@@ -146,7 +140,7 @@ def make_rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session):
         {
             "id": 1,
             "timestamp": "2016-04-11 12:00:00",
-            "feature1__avg_over_1_day_rolling_windows": 266.6666564941406,
+            "feature1__avg_over_1_day_rolling_windows": 266.6666666666667,
             "feature2__avg_over_1_day_rolling_windows": 300.0,
         },
         {
@@ -160,12 +154,6 @@ def make_rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session):
             "timestamp": "2016-04-12 12:00:00",
             "feature1__avg_over_1_day_rolling_windows": 400.0,
             "feature2__avg_over_1_day_rolling_windows": 500.0,
-        },
-        {
-            "id": 1,
-            "timestamp": "2016-04-23 00:00:00",
-            "feature1__avg_over_1_day_rolling_windows": 1000.0,
-            "feature2__avg_over_1_day_rolling_windows": 1100.0,
         },
     ]
     df = spark_session.read.json(
@@ -354,7 +342,6 @@ def timestamp_c():
 
 
 @fixture
-<<<<<<< HEAD
 def feature_set():
     feature_set = FeatureSet(
         name="feature_set",
@@ -392,60 +379,26 @@ def feature_set():
 
 @fixture
 def agg_feature_set():
-    feature_set = AggregatedFeatureSet(
-        name="feature_set",
-=======
-def agg_feature_set():
     return AggregatedFeatureSet(
         name="name",
->>>>>>> style compliant
         entity="entity",
         description="description",
         features=[
             Feature(
                 name="feature1",
-<<<<<<< HEAD
                 description="test",
                 transformation=AggregatedTransform(
-                    functions=[
-                        Function(functions.avg, DataType.DOUBLE),
-                        Function(functions.stddev_pop, DataType.FLOAT),
-                    ],
-=======
-                description="unit test",
-                transformation=AggregatedTransform(
-                    functions=[Function(functions.avg, DataType.FLOAT)]
->>>>>>> style compliant
+                    functions=[Function(functions.avg, DataType.DOUBLE),],
                 ),
             ),
             Feature(
                 name="feature2",
-<<<<<<< HEAD
                 description="test",
                 transformation=AggregatedTransform(
-                    functions=[Function(functions.count, DataType.ARRAY_STRING)]
+                    functions=[Function(functions.avg, DataType.DOUBLE),]
                 ),
             ),
         ],
-        keys=[
-            KeyFeature(
-                name="id",
-                description="The user's Main ID or device ID",
-                dtype=DataType.BIGINT,
-            )
-        ],
-        timestamp=TimestampFeature(),
-    ).with_windows(definitions=["1 week", "2 days"])
-
-    return feature_set
-=======
-                description="unit test",
-                transformation=AggregatedTransform(
-                    functions=[Function(functions.avg, DataType.FLOAT)]
-                ),
-            ),
-        ],
-        keys=[KeyFeature(name="id", description="description", dtype=DataType.INTEGER)],
+        keys=[KeyFeature(name="id", description="description", dtype=DataType.BIGINT,)],
         timestamp=TimestampFeature(),
     )
->>>>>>> style compliant

--- a/tests/unit/butterfree/transform/conftest.py
+++ b/tests/unit/butterfree/transform/conftest.py
@@ -388,14 +388,14 @@ def agg_feature_set():
                 name="feature1",
                 description="test",
                 transformation=AggregatedTransform(
-                    functions=[Function(functions.avg, DataType.DOUBLE),],
+                    functions=[Function(functions.avg, DataType.DOUBLE)],
                 ),
             ),
             Feature(
                 name="feature2",
                 description="test",
                 transformation=AggregatedTransform(
-                    functions=[Function(functions.avg, DataType.DOUBLE),]
+                    functions=[Function(functions.avg, DataType.DOUBLE)]
                 ),
             ),
         ],

--- a/tests/unit/butterfree/transform/conftest.py
+++ b/tests/unit/butterfree/transform/conftest.py
@@ -445,7 +445,7 @@ def agg_feature_set():
                 ),
             ),
         ],
-        keys=[key_id],
-        timestamp=timestamp_c,
+        keys=[KeyFeature(name="id", description="description", dtype=DataType.INTEGER)],
+        timestamp=TimestampFeature(),
     )
 >>>>>>> style compliant

--- a/tests/unit/butterfree/transform/conftest.py
+++ b/tests/unit/butterfree/transform/conftest.py
@@ -6,6 +6,7 @@ from pytest import fixture
 
 from butterfree.constants import DataType
 from butterfree.constants.columns import TIMESTAMP_COLUMN
+<<<<<<< HEAD
 from butterfree.transform import FeatureSet
 from butterfree.transform.aggregated_feature_set import AggregatedFeatureSet
 from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
@@ -13,6 +14,11 @@ from butterfree.transform.transformations import (
     AggregatedTransform,
     SparkFunctionTransform,
 )
+=======
+from butterfree.transform.aggregated_feature_set import AggregatedFeatureSet
+from butterfree.transform.features import Feature, KeyFeature, TimestampFeature
+from butterfree.transform.transformations import AggregatedTransform
+>>>>>>> style compliant
 from butterfree.transform.utils import Function
 
 
@@ -160,7 +166,7 @@ def make_rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session):
             "timestamp": "2016-04-23 00:00:00",
             "feature1__avg_over_1_day_rolling_windows": 1000.0,
             "feature2__avg_over_1_day_rolling_windows": 1100.0,
-        }
+        },
     ]
     df = spark_session.read.json(
         spark_context.parallelize(data).map(lambda x: json.dumps(x))
@@ -168,6 +174,7 @@ def make_rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session):
     df = df.withColumn("timestamp", df.timestamp.cast(DataType.TIMESTAMP.spark))
 
     return df
+
 
 def make_fs(spark_context, spark_session):
     df = make_dataframe(spark_context, spark_session)
@@ -347,6 +354,7 @@ def timestamp_c():
 
 
 @fixture
+<<<<<<< HEAD
 def feature_set():
     feature_set = FeatureSet(
         name="feature_set",
@@ -386,21 +394,33 @@ def feature_set():
 def agg_feature_set():
     feature_set = AggregatedFeatureSet(
         name="feature_set",
+=======
+def agg_feature_set():
+    return AggregatedFeatureSet(
+        name="name",
+>>>>>>> style compliant
         entity="entity",
         description="description",
         features=[
             Feature(
                 name="feature1",
+<<<<<<< HEAD
                 description="test",
                 transformation=AggregatedTransform(
                     functions=[
                         Function(functions.avg, DataType.DOUBLE),
                         Function(functions.stddev_pop, DataType.FLOAT),
                     ],
+=======
+                description="unit test",
+                transformation=AggregatedTransform(
+                    functions=[Function(functions.avg, DataType.FLOAT)]
+>>>>>>> style compliant
                 ),
             ),
             Feature(
                 name="feature2",
+<<<<<<< HEAD
                 description="test",
                 transformation=AggregatedTransform(
                     functions=[Function(functions.count, DataType.ARRAY_STRING)]
@@ -418,3 +438,14 @@ def agg_feature_set():
     ).with_windows(definitions=["1 week", "2 days"])
 
     return feature_set
+=======
+                description="unit test",
+                transformation=AggregatedTransform(
+                    functions=[Function(functions.avg, DataType.FLOAT)]
+                ),
+            ),
+        ],
+        keys=[key_id],
+        timestamp=timestamp_c,
+    )
+>>>>>>> style compliant

--- a/tests/unit/butterfree/transform/conftest.py
+++ b/tests/unit/butterfree/transform/conftest.py
@@ -135,6 +135,40 @@ def make_rolling_windows_agg_dataframe(spark_context, spark_session):
     return df
 
 
+def make_rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session):
+    data = [
+        {
+            "id": 1,
+            "timestamp": "2016-04-11 12:00:00",
+            "feature1__avg_over_1_day_rolling_windows": 266.6666564941406,
+            "feature2__avg_over_1_day_rolling_windows": 300.0,
+        },
+        {
+            "id": 1,
+            "timestamp": "2016-04-12 00:00:00",
+            "feature1__avg_over_1_day_rolling_windows": 300.0,
+            "feature2__avg_over_1_day_rolling_windows": 350.0,
+        },
+        {
+            "id": 1,
+            "timestamp": "2016-04-12 12:00:00",
+            "feature1__avg_over_1_day_rolling_windows": 400.0,
+            "feature2__avg_over_1_day_rolling_windows": 500.0,
+        },
+        {
+            "id": 1,
+            "timestamp": "2016-04-23 00:00:00",
+            "feature1__avg_over_1_day_rolling_windows": 1000.0,
+            "feature2__avg_over_1_day_rolling_windows": 1100.0,
+        }
+    ]
+    df = spark_session.read.json(
+        spark_context.parallelize(data).map(lambda x: json.dumps(x))
+    )
+    df = df.withColumn("timestamp", df.timestamp.cast(DataType.TIMESTAMP.spark))
+
+    return df
+
 def make_fs(spark_context, spark_session):
     df = make_dataframe(spark_context, spark_session)
     df = (
@@ -239,6 +273,11 @@ def output_filtering_dataframe(spark_context, spark_session):
 @fixture
 def rolling_windows_agg_dataframe(spark_context, spark_session):
     return make_rolling_windows_agg_dataframe(spark_context, spark_session)
+
+
+@fixture
+def rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session):
+    return make_rolling_windows_hour_slide_agg_dataframe(spark_context, spark_session)
 
 
 @fixture

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -52,8 +52,6 @@ class TestAggregatedFeatureSet:
 
     def test_agg_feature_set_with_window(
         self,
-        key_id,
-        timestamp_c,
         dataframe,
         rolling_windows_agg_dataframe,
         agg_feature_set,
@@ -74,8 +72,6 @@ class TestAggregatedFeatureSet:
 
     def test_agg_feature_set_with_smaller_slide(
         self,
-        key_id,
-        timestamp_c,
         dataframe,
         rolling_windows_hour_slide_agg_dataframe,
         agg_feature_set,

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -51,33 +51,16 @@ class TestAggregatedFeatureSet:
             ).construct(dataframe, spark_client)
 
     def test_agg_feature_set_with_window(
-        self, key_id, timestamp_c, dataframe, rolling_windows_agg_dataframe
+        self,
+        key_id,
+        timestamp_c,
+        dataframe,
+        rolling_windows_agg_dataframe,
+        agg_feature_set,
     ):
         spark_client = SparkClient()
 
-        fs = AggregatedFeatureSet(
-            name="name",
-            entity="entity",
-            description="description",
-            features=[
-                Feature(
-                    name="feature1",
-                    description="unit test",
-                    transformation=AggregatedTransform(
-                        functions=[Function(functions.avg, DataType.FLOAT)]
-                    ),
-                ),
-                Feature(
-                    name="feature2",
-                    description="unit test",
-                    transformation=AggregatedTransform(
-                        functions=[Function(functions.avg, DataType.FLOAT)]
-                    ),
-                ),
-            ],
-            keys=[key_id],
-            timestamp=timestamp_c,
-        ).with_windows(definitions=["1 week"])
+        fs = agg_feature_set.with_windows(definitions=["1 week"])
 
         # raises without end date
         with pytest.raises(ValueError):
@@ -90,33 +73,16 @@ class TestAggregatedFeatureSet:
         assert_dataframe_equality(output_df, rolling_windows_agg_dataframe)
 
     def test_agg_feature_set_with_smaller_slide(
-        self, key_id, timestamp_c, dataframe, rolling_windows_hour_slide_agg_dataframe
+        self,
+        key_id,
+        timestamp_c,
+        dataframe,
+        rolling_windows_hour_slide_agg_dataframe,
+        agg_feature_set,
     ):
         spark_client = SparkClient()
 
-        fs = AggregatedFeatureSet(
-            name="name",
-            entity="entity",
-            description="description",
-            features=[
-                Feature(
-                    name="feature1",
-                    description="unit test",
-                    transformation=AggregatedTransform(
-                        functions=[Function(functions.avg, DataType.FLOAT)]
-                    ),
-                ),
-                Feature(
-                    name="feature2",
-                    description="unit test",
-                    transformation=AggregatedTransform(
-                        functions=[Function(functions.avg, DataType.FLOAT)]
-                    ),
-                ),
-            ],
-            keys=[key_id],
-            timestamp=timestamp_c,
-        ).with_windows(definitions=["1 day"], slide="12 hours")
+        fs = agg_feature_set.with_windows(definitions=["1 day"], slide="12 hours")
 
         # raises without end date
         with pytest.raises(ValueError):

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -1,11 +1,8 @@
 import pytest
 from pyspark.sql import functions
 from pyspark.sql.types import (
-    ArrayType,
     DoubleType,
-    FloatType,
     LongType,
-    StringType,
     TimestampType,
 )
 
@@ -51,10 +48,7 @@ class TestAggregatedFeatureSet:
             ).construct(dataframe, spark_client)
 
     def test_agg_feature_set_with_window(
-        self,
-        dataframe,
-        rolling_windows_agg_dataframe,
-        agg_feature_set,
+        self, dataframe, rolling_windows_agg_dataframe, agg_feature_set,
     ):
         spark_client = SparkClient()
 
@@ -71,10 +65,7 @@ class TestAggregatedFeatureSet:
         assert_dataframe_equality(output_df, rolling_windows_agg_dataframe)
 
     def test_agg_feature_set_with_smaller_slide(
-        self,
-        dataframe,
-        rolling_windows_hour_slide_agg_dataframe,
-        agg_feature_set,
+        self, dataframe, rolling_windows_hour_slide_agg_dataframe, agg_feature_set,
     ):
         spark_client = SparkClient()
 
@@ -103,28 +94,20 @@ class TestAggregatedFeatureSet:
                 "primary_key": False,
             },
             {
-                "column_name": "feature1__stddev_pop_over_1_week_rolling_windows",
-                "type": FloatType(),
+                "column_name": "feature2__avg_over_1_week_rolling_windows",
+                "type": DoubleType(),
                 "primary_key": False,
             },
             {
-                "column_name": "feature1__stddev_pop_over_2_days_rolling_windows",
-                "type": FloatType(),
-                "primary_key": False,
-            },
-            {
-                "column_name": "feature2__count_over_1_week_rolling_windows",
-                "type": ArrayType(StringType(), True),
-                "primary_key": False,
-            },
-            {
-                "column_name": "feature2__count_over_2_days_rolling_windows",
-                "type": ArrayType(StringType(), True),
+                "column_name": "feature2__avg_over_2_days_rolling_windows",
+                "type": DoubleType(),
                 "primary_key": False,
             },
         ]
 
-        schema = agg_feature_set.get_schema()
+        schema = agg_feature_set.with_windows(
+            definitions=["1 week", "2 days"]
+        ).get_schema()
 
         assert schema == expected_schema
 
@@ -357,7 +340,9 @@ class TestAggregatedFeatureSet:
         assert_dataframe_equality(target_df, output_df)
 
     def test_define_start_date(self, agg_feature_set):
-        start_date = agg_feature_set.define_start_date("2020-08-04")
+        start_date = agg_feature_set.with_windows(
+            definitions=["1 week", "2 days"]
+        ).define_start_date("2020-08-04")
 
         assert isinstance(start_date, str)
         assert start_date == "2020-07-27"

--- a/tests/unit/butterfree/transform/test_aggregated_feature_set.py
+++ b/tests/unit/butterfree/transform/test_aggregated_feature_set.py
@@ -1,10 +1,6 @@
 import pytest
 from pyspark.sql import functions
-from pyspark.sql.types import (
-    DoubleType,
-    LongType,
-    TimestampType,
-)
+from pyspark.sql.types import DoubleType, LongType, TimestampType
 
 from butterfree.clients import SparkClient
 from butterfree.constants import DataType


### PR DESCRIPTION
## Why? :open_book:
We want to be able to run time aggregations with different slide durations.

## What? :wrench:
Add the slide parameter to `with_windows` function. Slide durations different of 1 day won't use the gap-filling technique we've been using to fix the problem of not updating the aggregations when no events happen.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release

## How everything was tested? :straight_ruler:
Unit testing aggregations with slide duration smaller than 1 day.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
By not applying the same gap-filling technique, we require the client to make sure it is not using an old aggregation result. The problem is that we run a deduplication logic under the hood, not storing rows with unchanged feature values. So, if the aggregation result doesn't, the row won't be saved into the feature store and the users will find older results there. I don't know, exactly, how we should solve this (unless we start working on a service layer for the feature store, to handle these internal concerns).