### PR TITLE
[MLOP-671] Implement get_schema on Spark client

### DIFF
--- a/butterfree/clients/spark_client.py
+++ b/butterfree/clients/spark_client.py
@@ -276,6 +276,16 @@ class SparkClient(AbstractClient):
 
     @staticmethod
     def _filter_schema(schema: DataFrame) -> List[str]:
+        """Returns filtered schema with the desired information.
+
+        Attributes:
+            schema: desired table.
+
+        Returns:
+            A list of strings in the format
+            ['{"column_name": "example1", type: "Spark_type"}', ...]
+
+        """
         return (
             schema.filter(
                 ~schema.col_name.isin(
@@ -287,12 +297,22 @@ class SparkClient(AbstractClient):
         )
 
     def _convert_schema(self, schema: DataFrame) -> List[Dict[str, str]]:
-        schema_list = self._filter_schema(schema)
-        schema = []
-        for row in schema_list:
-            schema.append(json.loads(row))
+        """Returns schema with the desired information.
 
-        return schema
+        Attributes:
+            schema: desired table.
+
+        Returns:
+            A list of dictionaries in the format
+            [{"column_name": "example1", type: "Spark_type"}, ...]
+
+        """
+        schema_list = self._filter_schema(schema)
+        converted_schema = []
+        for row in schema_list:
+            converted_schema.append(json.loads(row))
+
+        return converted_schema
 
     def get_schema(self, table: str, database: str) -> List[Dict[str, str]]:
         """Returns desired table schema.
@@ -301,7 +321,7 @@ class SparkClient(AbstractClient):
             table: desired table.
 
         Returns:
-            A list dictionaries in the format
+            A list of dictionaries in the format
             [{"column_name": "example1", type: "Spark_type"}, ...]
 
         """


### PR DESCRIPTION
## Why? :open_book:
In order to properly perform migrations, it was necessary to implement a method to retrieve the schema from a given table from Spark metastore. 

## What? :wrench:
Implement ```get_schema``` method within Spark client.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How everything was tested? :straight_ruler:
Unit test.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
