### PR TITLE
[BUG] Apply create_partitions to historical validate

### DIFF
--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -225,10 +225,7 @@ class HistoricalFeatureStoreWriter(Writer):
         Raises:
             AssertionError: if count of written data doesn't match count in current
                 feature set dataframe.
-
         """
-        # dataframe = self._create_partitions(dataframe)
-
         table_name = (
             f"{feature_set.name}"
             if self.interval_mode and not self.debug_mode
@@ -242,7 +239,9 @@ class HistoricalFeatureStoreWriter(Writer):
         written_count = (
             spark_client.read(
                 self.db_config.format_,
-                path=self.db_config.get_path_with_partitions(table_name, self._create_partitions(dataframe)),
+                path=self.db_config.get_path_with_partitions(
+                    table_name, self._create_partitions(dataframe)
+                ),
             ).count()
             if self.interval_mode and not self.debug_mode
             else spark_client.read_table(table_name).count()

--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -227,6 +227,8 @@ class HistoricalFeatureStoreWriter(Writer):
                 feature set dataframe.
 
         """
+        # dataframe = self._create_partitions(dataframe)
+
         table_name = (
             f"{feature_set.name}"
             if self.interval_mode and not self.debug_mode
@@ -240,7 +242,7 @@ class HistoricalFeatureStoreWriter(Writer):
         written_count = (
             spark_client.read(
                 self.db_config.format_,
-                path=self.db_config.get_path_with_partitions(table_name, dataframe),
+                path=self.db_config.get_path_with_partitions(table_name, self._create_partitions(dataframe)),
             ).count()
             if self.interval_mode and not self.debug_mode
             else spark_client.read_table(table_name).count()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev3"
+__version__ = "1.2.0.dev4"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
We need to partition values to use validate for IntervalMode.

## What? :wrench:
- HistoricalWriterFeatureStore

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- Unit tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
