### PR TITLE
[BUG] Fix key path for validate read

### DIFF
--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -227,7 +227,7 @@ class HistoricalFeatureStoreWriter(Writer):
                 feature set dataframe.
         """
         table_name = (
-            f"{feature_set.name}"
+            os.path.join("historical", feature_set.entity, feature_set.name)
             if self.interval_mode and not self.debug_mode
             else (
                 f"{self.database}.{feature_set.name}"


### PR DESCRIPTION
## Why? :open_book:
The key path needs to the entity name.

## What? :wrench:
- HistoricalWriterFeatureStore

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- Unit tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
