### PR TITLE
Fix link in Buttefree Doc

### DIFF
--- a/docs/source/extract.md
+++ b/docs/source/extract.md
@@ -53,4 +53,4 @@ source = Source(
 )
 ```
 
-It's important to state that we have some pre-processing methods as well, such as filter and pivot. Feel free to check them [here](https://github.com/quintoandar/butterfree/tree/staging/butterfree/core/extract/pre_processing).
+It's important to state that we have some pre-processing methods as well, such as filter and pivot. Feel free to check them [here](https://github.com/quintoandar/butterfree/tree/master/butterfree/extract/pre_processing).


### PR DESCRIPTION
## Why? :open_book:
The link in Butterfree Docs for Extract Pre-processing methods is wrong.

## What? :wrench:
- Extract Markdown

## Type of change
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
