### PR TITLE
[BUG] Fix Cassandra Connect Session

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev12"
+__version__ = "1.2.0.dev13"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:

--- a/tests/unit/butterfree/clients/test_cassandra_client.py
+++ b/tests/unit/butterfree/clients/test_cassandra_client.py
@@ -88,31 +88,3 @@ class TestCassandraClient:
         query = cassandra_client.sql.call_args[0][0]
 
         assert sanitize_string(query) == sanitize_string(expected_query)
-
-    def test_cassandra_without_session(self, cassandra_client: CassandraClient) -> None:
-        cassandra_client = cassandra_client
-
-        with pytest.raises(
-            RuntimeError, match="There's no session available for this query."
-        ):
-            cassandra_client.sql(
-                query="select feature1, feature2 from cassandra_feature_set"
-            )
-        with pytest.raises(
-            RuntimeError, match="There's no session available for this query."
-        ):
-            cassandra_client.create_table(
-                [
-                    {"column_name": "id", "type": "int", "primary_key": True},
-                    {
-                        "column_name": "rent_per_month",
-                        "type": "float",
-                        "primary_key": False,
-                    },
-                ],
-                "test",
-            )
-        with pytest.raises(
-            RuntimeError, match="There's no session available for this query."
-        ):
-            cassandra_client.get_schema("test")

--- a/tests/unit/butterfree/clients/test_cassandra_client.py
+++ b/tests/unit/butterfree/clients/test_cassandra_client.py
@@ -1,8 +1,6 @@
 from typing import Any, Dict, List
 from unittest.mock import MagicMock
 
-import pytest
-
 from butterfree.clients import CassandraClient
 from butterfree.clients.cassandra_client import CassandraColumn
 


### PR DESCRIPTION
## Why? :open_book:
We noticed that when creating the session for CassandraClient we were not making the connection, so the session did not always exist.

## What? :wrench:
- CassandraClient

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How everything was tested? :straight_ruler:
- Unit tests and ["Databricks Tests"](https://dbc-931ee6e0-6803.cloud.databricks.com/?o=4531937035440038#notebook/1759065719312531/command/1759065719312565) 

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
