### PR TITLE
[BUG] Fix migration query

### DIFF
--- a/butterfree/migrations/database_migration/cassandra_migration.py
+++ b/butterfree/migrations/database_migration/cassandra_migration.py
@@ -75,7 +75,7 @@ class CassandraMigration(DatabaseMigration):
 
         return f"ALTER TABLE {table_name} ADD ({parsed_columns});"
 
-    def _get_alter_column_type_query(self, columns: List[Diff], table_name: str) -> str:
+    def _get_alter_column_type_query(self, column: Diff, table_name: str) -> str:
         """Creates CQL statement to alter columns' types.
 
         Args:
@@ -86,9 +86,9 @@ class CassandraMigration(DatabaseMigration):
             Alter column type query.
 
         """
-        parsed_columns = self._get_parsed_columns(columns)
+        parsed_columns = self._get_parsed_columns([column])
 
-        return f"ALTER TABLE {table_name} ALTER ({parsed_columns});"
+        return f"ALTER TABLE {table_name} ALTER {parsed_columns};"
 
     @staticmethod
     def _get_create_table_query(columns: List[Dict[str, Any]], table_name: str) -> str:

--- a/butterfree/migrations/database_migration/database_migration.py
+++ b/butterfree/migrations/database_migration/database_migration.py
@@ -93,7 +93,7 @@ class DatabaseMigration(ABC):
         pass
 
     @abstractmethod
-    def _get_alter_column_type_query(self, columns: List[Diff], table_name: str) -> str:
+    def _get_alter_column_type_query(self, column: Diff, table_name: str) -> str:
         """Creates desired statement to alter columns' types.
 
         Args:
@@ -152,10 +152,11 @@ class DatabaseMigration(ABC):
                 )
                 queries.append(drop_columns_query)
         if alter_type_items:
-            alter_column_types_query = self._get_alter_column_type_query(
-                alter_type_items, table_name
-            )
-            queries.append(alter_column_types_query)
+            for item in alter_type_items:
+                alter_column_types_query = self._get_alter_column_type_query(
+                    item, table_name
+                )
+                queries.append(alter_column_types_query)
         if alter_key_items:
             logger.info("This operation is not supported by Spark.")
 

--- a/butterfree/migrations/database_migration/metastore_migration.py
+++ b/butterfree/migrations/database_migration/metastore_migration.py
@@ -74,7 +74,7 @@ class MetastoreMigration(DatabaseMigration):
             f"ADD IF NOT EXISTS columns ({parsed_columns});"
         )
 
-    def _get_alter_column_type_query(self, columns: List[Diff], table_name: str) -> str:
+    def _get_alter_column_type_query(self, column: Diff, table_name: str) -> str:
         """Creates SQL statement to alter columns' types.
 
         Args:
@@ -85,9 +85,9 @@ class MetastoreMigration(DatabaseMigration):
             Alter column type query.
 
         """
-        parsed_columns = self._get_parsed_columns(columns)
+        parsed_columns = self._get_parsed_columns([column])
 
-        return f"ALTER TABLE {table_name} ALTER COLUMN ({parsed_columns});"
+        return f"ALTER TABLE {table_name} ALTER COLUMN {parsed_columns};"
 
     def _get_create_table_query(
         self, columns: List[Dict[str, Any]], table_name: str

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev13"
+__version__ = "1.2.0.dev14"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:

--- a/tests/unit/butterfree/migrations/database_migration/test_cassandra_migration.py
+++ b/tests/unit/butterfree/migrations/database_migration/test_cassandra_migration.py
@@ -8,7 +8,7 @@ class TestCassandraMigration:
             "ALTER TABLE table_name ADD (new_feature FloatType);",
             "ALTER TABLE table_name DROP (feature1__avg_over_2_days_rolling_windows);",
             "ALTER TABLE table_name ALTER "
-            "(feature1__avg_over_1_week_rolling_windows FloatType);",
+            "feature1__avg_over_1_week_rolling_windows FloatType;",
         ]
         query = cassandra_migration.create_query(fs_schema, "table_name", db_schema)
 
@@ -19,7 +19,7 @@ class TestCassandraMigration:
         expected_query = [
             "ALTER TABLE table_name ADD (new_feature FloatType);",
             "ALTER TABLE table_name ALTER "
-            "(feature1__avg_over_1_week_rolling_windows FloatType);",
+            "feature1__avg_over_1_week_rolling_windows FloatType;",
         ]
         query = cassandra_migration.create_query(
             fs_schema, "table_name", db_schema, True

--- a/tests/unit/butterfree/migrations/database_migration/test_metastore_migration.py
+++ b/tests/unit/butterfree/migrations/database_migration/test_metastore_migration.py
@@ -11,7 +11,7 @@ class TestMetastoreMigration:
             "ALTER TABLE table_name DROP IF EXISTS "
             "(feature1__avg_over_2_days_rolling_windows None);",
             "ALTER TABLE table_name ALTER COLUMN "
-            "(feature1__avg_over_1_week_rolling_windows FloatType);",
+            "feature1__avg_over_1_week_rolling_windows FloatType;",
         ]
 
         query = metastore_migration.create_query(fs_schema, "table_name", db_schema)
@@ -25,7 +25,7 @@ class TestMetastoreMigration:
             "ALTER TABLE test.table_name ADD IF NOT EXISTS "
             "columns (new_feature FloatType);",
             "ALTER TABLE table_name ALTER COLUMN "
-            "(feature1__avg_over_1_week_rolling_windows FloatType);",
+            "feature1__avg_over_1_week_rolling_windows FloatType;",
         ]
 
         query = metastore_migration.create_query(


### PR DESCRIPTION
## Why? :open_book:
When we change the column type in Cassandra, the query can't receive more than one column, that is, we have to make a query for each column that we want to change the type of.

## What? :wrench:
- DatabaseMigration (Cassandra and Metastore)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- Unit Tests.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
