### PR TITLE
Fix migration query: Add K_TYPE.

### DIFF
--- a/butterfree/migrations/database_migration/cassandra_migration.py
+++ b/butterfree/migrations/database_migration/cassandra_migration.py
@@ -88,7 +88,9 @@ class CassandraMigration(DatabaseMigration):
         """
         parsed_columns = self._get_parsed_columns([column])
 
-        return f"ALTER TABLE {table_name} ALTER {parsed_columns};"
+        return (
+            f"ALTER TABLE {table_name} ALTER {parsed_columns.replace(' ', ' TYPE ')};"
+        )
 
     @staticmethod
     def _get_create_table_query(columns: List[Dict[str, Any]], table_name: str) -> str:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev14"
+__version__ = "1.2.0.dev15"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:

--- a/tests/unit/butterfree/migrations/database_migration/test_cassandra_migration.py
+++ b/tests/unit/butterfree/migrations/database_migration/test_cassandra_migration.py
@@ -8,7 +8,7 @@ class TestCassandraMigration:
             "ALTER TABLE table_name ADD (new_feature FloatType);",
             "ALTER TABLE table_name DROP (feature1__avg_over_2_days_rolling_windows);",
             "ALTER TABLE table_name ALTER "
-            "feature1__avg_over_1_week_rolling_windows FloatType;",
+            "feature1__avg_over_1_week_rolling_windows TYPE FloatType;",
         ]
         query = cassandra_migration.create_query(fs_schema, "table_name", db_schema)
 
@@ -19,7 +19,7 @@ class TestCassandraMigration:
         expected_query = [
             "ALTER TABLE table_name ADD (new_feature FloatType);",
             "ALTER TABLE table_name ALTER "
-            "feature1__avg_over_1_week_rolling_windows FloatType;",
+            "feature1__avg_over_1_week_rolling_windows TYPE FloatType;",
         ]
         query = cassandra_migration.create_query(
             fs_schema, "table_name", db_schema, True


### PR DESCRIPTION
## Why? :open_book:
To apply a Cassandra query with alter type, we need to K_TYPE.

## What? :wrench:
- CassandraMigration

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- UnitTests

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
