### PR TITLE
MLOP-642 Document migration in Butterfree

### DIFF
--- a/docs/source/butterfree.clients.rst
+++ b/docs/source/butterfree.clients.rst
@@ -22,7 +22,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.configs.db.rst
+++ b/docs/source/butterfree.configs.db.rst
@@ -23,11 +23,10 @@ Submodules
    :show-inheritance:
 
 
-.. automodule:: butterfree.configs.db.s3_config
+.. automodule:: butterfree.configs.db.metastore_config
    :members:
    :undoc-members:
    :show-inheritance:
-
 
 Module contents
 ---------------

--- a/docs/source/butterfree.configs.rst
+++ b/docs/source/butterfree.configs.rst
@@ -18,6 +18,12 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
+
+.. automodule:: butterfree.configs.logger
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/source/butterfree.constants.rst
+++ b/docs/source/butterfree.constants.rst
@@ -17,11 +17,22 @@ Submodules
    :show-inheritance:
 
 
+.. automodule:: butterfree.constants.migrations
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: butterfree.constants.spark_constants
    :members:
    :undoc-members:
    :show-inheritance:
 
+
+.. automodule:: butterfree.constants.window_definitions
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Module contents
 ---------------

--- a/docs/source/butterfree.dataframe_service.rst
+++ b/docs/source/butterfree.dataframe_service.rst
@@ -5,11 +5,22 @@ Submodules
 ----------
 
 
-.. automodule:: butterfree.dataframe_service.repartition
+.. automodule:: butterfree.dataframe_service.incremental_strategy
    :members:
    :undoc-members:
    :show-inheritance:
 
+
+.. automodule:: butterfree.dataframe_service.partitioning
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: butterfree.dataframe_service.repartition
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Module contents
 ---------------

--- a/docs/source/butterfree.extract.pre_processing.rst
+++ b/docs/source/butterfree.extract.pre_processing.rst
@@ -34,7 +34,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.extract.readers.rst
+++ b/docs/source/butterfree.extract.readers.rst
@@ -28,7 +28,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.extract.rst
+++ b/docs/source/butterfree.extract.rst
@@ -19,7 +19,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.hooks.rst
+++ b/docs/source/butterfree.hooks.rst
@@ -1,0 +1,33 @@
+butterfree.hooks package
+========================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   butterfree.hooks.schema_compatibility
+
+Submodules
+----------
+
+
+.. automodule:: butterfree.hooks.hook
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: butterfree.hooks.hookable_component
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: butterfree.hooks
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/butterfree.hooks.schema_compatibility.rst
+++ b/docs/source/butterfree.hooks.schema_compatibility.rst
@@ -1,0 +1,25 @@
+butterfree.hooks.schema\_compatibility package
+==============================================
+
+Submodules
+----------
+
+
+.. automodule:: butterfree.hooks.schema_compatibility.cassandra_table_schema_compatibility_hook
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: butterfree.hooks.schema_compatibility.spark_table_schema_compatibility_hook
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: butterfree.hooks.schema_compatibility
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/butterfree.load.processing.rst
+++ b/docs/source/butterfree.load.processing.rst
@@ -10,7 +10,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.load.rst
+++ b/docs/source/butterfree.load.rst
@@ -19,7 +19,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.load.writers.rst
+++ b/docs/source/butterfree.load.writers.rst
@@ -22,7 +22,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.migrations.database_migration.rst
+++ b/docs/source/butterfree.migrations.database_migration.rst
@@ -1,0 +1,31 @@
+butterfree.migrations.database\_migration package
+=================================================
+
+Submodules
+----------
+
+
+.. automodule:: butterfree.migrations.database_migration.cassandra_migration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: butterfree.migrations.database_migration.database_migration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. automodule:: butterfree.migrations.database_migration.metastore_migration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: butterfree.migrations.database_migration
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/butterfree.migrations.rst
+++ b/docs/source/butterfree.migrations.rst
@@ -1,5 +1,5 @@
-butterfree.configs package
-==========================
+butterfree.migrations package
+=============================
 
 Subpackages
 -----------
@@ -7,13 +7,13 @@ Subpackages
 .. toctree::
    :maxdepth: 4
 
-   butterfree.configs.db
+   butterfree.migrations.database_migration
 
 Submodules
 ----------
 
 
-.. automodule:: butterfree.configs.environment
+.. automodule:: butterfree.migrations.migrate
    :members:
    :undoc-members:
    :show-inheritance:
@@ -21,7 +21,7 @@ Submodules
 Module contents
 ---------------
 
-.. automodule:: butterfree.configs
+.. automodule:: butterfree.migrations
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/butterfree.migrations.rst
+++ b/docs/source/butterfree.migrations.rst
@@ -9,15 +9,6 @@ Subpackages
 
    butterfree.migrations.database_migration
 
-Submodules
-----------
-
-
-.. automodule:: butterfree.migrations.migrate
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.pipelines.rst
+++ b/docs/source/butterfree.pipelines.rst
@@ -10,7 +10,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.reports.rst
+++ b/docs/source/butterfree.reports.rst
@@ -10,7 +10,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.rst
+++ b/docs/source/butterfree.rst
@@ -12,7 +12,9 @@ Subpackages
    butterfree.constants
    butterfree.dataframe_service
    butterfree.extract
+   butterfree.hooks
    butterfree.load
+   butterfree.migrations
    butterfree.pipelines
    butterfree.reports
    butterfree.testing

--- a/docs/source/butterfree.transform.features.rst
+++ b/docs/source/butterfree.transform.features.rst
@@ -22,7 +22,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.transform.rst
+++ b/docs/source/butterfree.transform.rst
@@ -26,7 +26,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.transform.transformations.rst
+++ b/docs/source/butterfree.transform.transformations.rst
@@ -54,7 +54,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.transform.transformations.user_defined_functions.rst
+++ b/docs/source/butterfree.transform.transformations.user_defined_functions.rst
@@ -16,7 +16,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.transform.utils.rst
+++ b/docs/source/butterfree.transform.utils.rst
@@ -22,7 +22,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/butterfree.validations.rst
+++ b/docs/source/butterfree.validations.rst
@@ -16,7 +16,6 @@ Submodules
    :undoc-members:
    :show-inheritance:
 
-
 Module contents
 ---------------
 

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -1,0 +1,23 @@
+# Command-line Interface (CLI)
+
+Butterfree has now a command-line interface, introduced with the new automatic migration ability.
+
+As soon as you install butterfree, you can check what's available through butterfree's cli with:
+
+```shell
+$~ butterfree help
+```
+
+### Automated Database Schema Migration
+
+When developing your feature sets, you need also to prepare your database for the changes
+to come into your Feature Store. Normally, when creating a new feature set, you needed
+to manually create a new table in cassandra. Or, when creating a new feature in an existing
+feature set, you needed to create new column in cassandra too.
+
+Now, you can just use `butterfree migrate apply ...`, butterfree will scan your python
+files, looking for classes that inherit from `butterfree.pipelines.FeatureSetPipeline`,
+then compare its schema with the database schema where the feature set would be written.
+Then it will prepare migration queries and run against the databases.
+
+For more information, please, check `butterfree migrate apply help` :)

--- a/docs/source/cli.md
+++ b/docs/source/cli.md
@@ -5,7 +5,7 @@ Butterfree has now a command-line interface, introduced with the new automatic m
 As soon as you install butterfree, you can check what's available through butterfree's cli with:
 
 ```shell
-$~ butterfree help
+$~ butterfree --help
 ```
 
 ### Automated Database Schema Migration
@@ -20,4 +20,13 @@ files, looking for classes that inherit from `butterfree.pipelines.FeatureSetPip
 then compare its schema with the database schema where the feature set would be written.
 Then it will prepare migration queries and run against the databases.
 
-For more information, please, check `butterfree migrate apply help` :)
+For more information, please, check `butterfree migrate apply --help` :)
+
+### Supported databases
+
+This functionality currently supports only the **Cassandra** database, which is the default
+storage for an Online Feature Store built with Butterfree. Nonetheless, it was made with
+the intent to be easily extended for other databases.
+
+Also, each database has its own rules for schema migration commands. Some changes may
+still require manual interference.

--- a/docs/source/home.md
+++ b/docs/source/home.md
@@ -10,6 +10,7 @@ The main idea is for this repository to be a set of tools for easing [ETLs](http
 - [Load](#load)
 - [Streaming](#streaming)
 - [Setup Configuration](#setup-configuration)
+- [Command-line Interface](#command-line-interface)
 
 ## What is going on here
 
@@ -61,3 +62,8 @@ We also support streaming pipelines in Butterfree. More information is available
 ## Setup Configuration
 
 Some configurations are needed to run your ETL pipelines. Detailed information is provided at the [Configuration Section](configuration.md)
+
+## Command-line Interface
+
+Butterfree has its own command-line interface, to manage your feature sets. Detailed information
+provided by the [Command-line Interface](cli.md) section.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,3 +22,4 @@ Navigation
    stream
    configuration
    modules
+   cli

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -5,3 +5,7 @@ jupyter==1.0.0
 twine==3.1.1
 mypy==0.790
 pyspark-stubs==3.0.0
+sphinx==3.5.4
+sphinxemoji==0.1.8
+sphinx-rtd-theme==0.5.2
+recommonmark==0.7.1


### PR DESCRIPTION
## Why? :open_book:
After adding the new tool for schema migration, we must add some initial notes about it on our documentation.

## What? :wrench:
- Adding `cli.md` describing more about the new tool.
- Run update-docs created and updated docs that were outdated.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Release