### PR TITLE
[MLOP-729][BUG] Fix method to generate agg feature name

### DIFF
--- a/butterfree/transform/transformations/aggregated_transform.py
+++ b/butterfree/transform/transformations/aggregated_transform.py
@@ -88,7 +88,7 @@ class AggregatedTransform(TransformComponent):
                 """
             )
 
-        base_name = "__".join([self._parent.name, function.__name__])
+        base_name = "__".join([self._parent.name, str(function.__name__).lower()])
         return base_name
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev17"
+__version__ = "1.2.0.dev18"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:


### PR DESCRIPTION
## Why? :open_book:
To not have discrepancies with names in storages (like Cassandra) with CaseSensitive, we apply `str.lower()` to the function name applied in the AggregatedTransform.

## What? :wrench:
- AggregatedTransform

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- Unit and integration test

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.
