### PR TITLE
[MLOP-691]  Include step to add partition to SparkMetastore during writing of Butterfree

### DIFF
--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -144,15 +144,17 @@ class HistoricalFeatureStoreWriter(Writer):
         dataframe = self._apply_transformations(dataframe)
 
         if self.interval_mode:
-            if self.debug_mode:
-                spark_client.create_temporary_view(
-                    dataframe=dataframe,
-                    name=f"historical_feature_store__{feature_set.name}",
-                )
-                return
+            partition_overwrite_mode = spark_client.conn.conf.get(
+                "spark.sql.sources.partitionOverwriteMode"
+            ).lower()
 
-            self._incremental_mode(feature_set, dataframe, spark_client)
-            return
+            if partition_overwrite_mode != "dynamic":
+                raise RuntimeError(
+                    "m=load_incremental_table, "
+                    "spark.sql.sources.partitionOverwriteMode={}, "
+                    "msg=partitionOverwriteMode have to "
+                    "be configured to 'dynamic'".format(partition_overwrite_mode)
+                )
 
         if self.debug_mode:
             spark_client.create_temporary_view(
@@ -169,34 +171,6 @@ class HistoricalFeatureStoreWriter(Writer):
             table_name=feature_set.name,
             partition_by=self.PARTITION_BY,
             **self.db_config.get_options(s3_key),
-        )
-
-    def _incremental_mode(
-        self, feature_set: FeatureSet, dataframe: DataFrame, spark_client: SparkClient
-    ) -> None:
-
-        partition_overwrite_mode = spark_client.conn.conf.get(
-            "spark.sql.sources.partitionOverwriteMode"
-        ).lower()
-
-        if partition_overwrite_mode != "dynamic":
-            raise RuntimeError(
-                "m=load_incremental_table, "
-                "spark.sql.sources.partitionOverwriteMode={}, "
-                "msg=partitionOverwriteMode have to be configured to 'dynamic'".format(
-                    partition_overwrite_mode
-                )
-            )
-
-        s3_key = os.path.join("historical", feature_set.entity, feature_set.name)
-        options = {"path": self.db_config.get_options(s3_key).get("path")}
-
-        spark_client.write_dataframe(
-            dataframe=dataframe,
-            format_=self.db_config.format_,
-            mode=self.db_config.mode,
-            **options,
-            partitionBy=self.PARTITION_BY,
         )
 
     def _assert_validation_count(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __package_name__ = "butterfree"
-__version__ = "1.2.0.dev18"
+__version__ = "1.2.0.dev19"
 __repository_url__ = "https://github.com/quintoandar/butterfree"
 
 with open("requirements.txt") as f:

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -51,7 +51,7 @@ class TestHistoricalFeatureStoreWriter:
     ):
         # given
         spark_client = SparkClient()
-        spark_client.write_dataframe = mocker.stub("write_dataframe")
+        spark_client.write_table = mocker.stub("write_table")
         spark_client.conn.conf.set(
             "spark.sql.sources.partitionOverwriteMode", "dynamic"
         )
@@ -63,21 +63,21 @@ class TestHistoricalFeatureStoreWriter:
             dataframe=feature_set_dataframe,
             spark_client=spark_client,
         )
-        result_df = spark_client.write_dataframe.call_args[1]["dataframe"]
+        result_df = spark_client.write_table.call_args[1]["dataframe"]
 
         # then
         assert_dataframe_equality(historical_feature_set_dataframe, result_df)
 
         assert (
-            writer.db_config.format_
-            == spark_client.write_dataframe.call_args[1]["format_"]
+            writer.database
+            == spark_client.write_table.call_args[1]["database"]
         )
         assert (
-            writer.db_config.mode == spark_client.write_dataframe.call_args[1]["mode"]
+            feature_set.name == spark_client.write_table.call_args[1]["table_name"]
         )
         assert (
             writer.PARTITION_BY
-            == spark_client.write_dataframe.call_args[1]["partitionBy"]
+            == spark_client.write_table.call_args[1]["partition_by"]
         )
 
     def test_write_interval_mode_invalid_partition_mode(
@@ -130,9 +130,12 @@ class TestHistoricalFeatureStoreWriter:
         historical_feature_set_dataframe,
         feature_set,
         spark_session,
+        mocker
     ):
         # given
         spark_client = SparkClient()
+        spark_client.write_dataframe = mocker.stub("write_dataframe")
+        spark_client.conn.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
         writer = HistoricalFeatureStoreWriter(debug_mode=True, interval_mode=True)
 
         # when

--- a/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
+++ b/tests/unit/butterfree/load/writers/test_historical_feature_store_writer.py
@@ -68,16 +68,10 @@ class TestHistoricalFeatureStoreWriter:
         # then
         assert_dataframe_equality(historical_feature_set_dataframe, result_df)
 
+        assert writer.database == spark_client.write_table.call_args[1]["database"]
+        assert feature_set.name == spark_client.write_table.call_args[1]["table_name"]
         assert (
-            writer.database
-            == spark_client.write_table.call_args[1]["database"]
-        )
-        assert (
-            feature_set.name == spark_client.write_table.call_args[1]["table_name"]
-        )
-        assert (
-            writer.PARTITION_BY
-            == spark_client.write_table.call_args[1]["partition_by"]
+            writer.PARTITION_BY == spark_client.write_table.call_args[1]["partition_by"]
         )
 
     def test_write_interval_mode_invalid_partition_mode(
@@ -130,12 +124,14 @@ class TestHistoricalFeatureStoreWriter:
         historical_feature_set_dataframe,
         feature_set,
         spark_session,
-        mocker
+        mocker,
     ):
         # given
         spark_client = SparkClient()
         spark_client.write_dataframe = mocker.stub("write_dataframe")
-        spark_client.conn.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
+        spark_client.conn.conf.set(
+            "spark.sql.sources.partitionOverwriteMode", "dynamic"
+        )
         writer = HistoricalFeatureStoreWriter(debug_mode=True, interval_mode=True)
 
         # when


### PR DESCRIPTION
## Why? :open_book:
The writing of the interval mode was just being saving the data in S3, that is, it wasn't taking the data to SparkMetastore.

## What? :wrench:
- HistoticalFSWriter

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
- Unit tests and Databricks.

## Checklist
- [x] My code follows the style guidelines of this project (docstrings, type hinting, and linter compliance);
- [x] I have performed a self-review of my own code;
- [x] I have made corresponding changes to the documentation;
- [x] I have added tests that prove my fix is effective or that my feature works;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
_Replace me for what the reviewer will need to pay attention to in the PR or just to cover any concerns after the merge._
