### PR TITLE
Add the missing link for H3 geohash

### DIFF
--- a/examples/simple_feature_set/simple_feature_set.ipynb
+++ b/examples/simple_feature_set/simple_feature_set.ipynb
@@ -89,7 +89,7 @@
     "| - | - | - | - | - | - | - | - | - | - | - | - | - | - |\n",
     "| int | timestamp | float | float | int | int | float | float | float | double | double | string | string | string |\n",
     "\n",
-    "For more information about H3 geohash click [here](https://h3geo.org/docs/comparisons/geohash)\n",
+    "For more information about H3 geohash click [here](https://h3geo.org/docs/)\n",
     "\n",
     "The following code blocks will show how to generate this feature set using Butterfree library:\n",
     "\n"

--- a/examples/spark_function_and_window/spark_function_and_window.ipynb
+++ b/examples/spark_function_and_window/spark_function_and_window.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "Note that we're going to compute two aggregated features, rent average and standard deviation, considering the two last occurrences (or events). It'd also be possible to define time windows, instead of windows based on events.\n",
     "\n",
-    "For more information about H3 geohash click [here]().\n",
+    "For more information about H3 geohash click [here](https://h3geo.org/docs/).\n",
     "\n",
     "The following code blocks will show how to generate this feature set using Butterfree library:\n",
     "\n"


### PR DESCRIPTION
## Why? :open_book:
This PR adds a missing link in the `examples/simple_feature_set/simple_feature_set.ipynb`. The link is referring to H3 Geohash information, currently the link in the markdown is empty and redirects to rendered notebook.
Fixes: #329 

## What? :wrench:
There is only one change being made in this PR and that is addition of a link to H3 Geohash information.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release

## How everything was tested? :straight_ruler:
There is no need to test anything, apart from the fact that the link that I have updated is the same link authors refer to. If its one and the same, then there is no need to test anything as there is no code changes.

## Checklist
- [ ] My code follows the style guidelines of this project (docstrings, type hinting and linter compliance);
- [ ] I have performed a self-review of my own code;
- [ ] I have made corresponding changes to the documentation;
- [ ] I have added tests that prove my fix is effective or that my feature works;
- [ ] New and existing unit tests pass locally with my changes;
- [ ] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.

## Attention Points :warning:
Reviewers need to verify that the link that I have added is the same link that the author of the notebook intended to add.