### PR TITLE
Update Github Actions Workflow runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   Pipeline:
     if: github.ref == 'refs/heads/master'
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-22.04
     container: quintoandar/python-3-7-java
 
     steps:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,7 +9,7 @@ jobs:
   Pipeline:
     if: github.ref == 'refs/heads/staging'
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-22.04
     container: quintoandar/python-3-7-java
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   Pipeline:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-22.04
     container: quintoandar/python-3-7-java
 
     steps:

--- a/requirements.lint.txt
+++ b/requirements.lint.txt
@@ -4,4 +4,5 @@ flake8-isort==2.8.0
 isort<5  # temporary fix
 flake8-docstrings==1.5.0
 flake8-bugbear==20.1.0
-flake8-bandit==2.1.2
+flake8-bandit==3.0.0
+

--- a/tests/unit/butterfree/configs/db/test_cassandra_config.py
+++ b/tests/unit/butterfree/configs/db/test_cassandra_config.py
@@ -230,6 +230,6 @@ class TestCassandraConfig:
             username="username", password="password", host="host", keyspace="keyspace"
         )
         assert cassandra_config.username == "username"
-        assert cassandra_config.password == "password"
+        assert cassandra_config.password == "password"  # noqa: S105
         assert cassandra_config.host == "host"
         assert cassandra_config.keyspace == "keyspace"


### PR DESCRIPTION
## Why? :open_book:
The runner used for executing the Github Actions appears to be outdated and not working.
The step will be stuck finding for a runner:
<img width="687" alt="image" src="https://user-images.githubusercontent.com/13151948/184149804-2c214f58-b2cd-4a96-a0aa-7fba5015ca32.png">


## What? :wrench:
- updating the runner to `ubuntu-22.04`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How everything was tested? :straight_ruler:
Running PR workflows
