### PR TITLE
fix(mlop-607) Change butterfree maintainers docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 recommonmark==0.6.0
-Sphinx==3.1.1
 sphinx-rtd-theme==0.4.3
 sphinxemoji==0.1.6
 typing-extensions==3.7.4.2


### PR DESCRIPTION
## Why? :open_book:
Today the Butterfree documentation uses my account to be hosted on Read the Docs, and the DevOps team created an account for QuintoAndar, so we need to change the management account.

## What? :wrench:
- Delete the Sphinx version.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have made corresponding changes to the documentation;
- [x] New and existing unit tests pass locally with my changes;
- [x] Add labels to distinguish the type of pull request. Available labels are `bug`, `enhancement`, `feature`, and `review`.