### PR TITLE
feat: Optional row count validation

### DIFF
--- a/butterfree/load/sink.py
+++ b/butterfree/load/sink.py
@@ -69,14 +69,15 @@ class Sink(HookableComponent):
         """
         failures = []
         for writer in self.writers:
-            try:
-                writer.validate(
-                    feature_set=feature_set,
-                    dataframe=dataframe,
-                    spark_client=spark_client,
-                )
-            except AssertionError as e:
-                failures.append(e)
+            if writer.row_count_validation:
+                try:
+                    writer.validate(
+                        feature_set=feature_set,
+                        dataframe=dataframe,
+                        spark_client=spark_client,
+                    )
+                except AssertionError as e:
+                    failures.append(e)
 
         if failures:
             raise RuntimeError(

--- a/butterfree/load/writers/writer.py
+++ b/butterfree/load/writers/writer.py
@@ -26,6 +26,7 @@ class Writer(ABC, HookableComponent):
         debug_mode: bool = False,
         interval_mode: bool = False,
         write_to_entity: bool = False,
+        row_count_validation: bool = True,
     ) -> None:
         super().__init__()
         self.db_config = db_config
@@ -33,6 +34,7 @@ class Writer(ABC, HookableComponent):
         self.debug_mode = debug_mode
         self.interval_mode = interval_mode
         self.write_to_entity = write_to_entity
+        self.row_count_validation = row_count_validation
 
     def with_(
         self, transformer: Callable[..., DataFrame], *args: Any, **kwargs: Any


### PR DESCRIPTION
## Why? :open_book:
For some cases there's no need to apply row count validation (e.g. when using DELTA as storage format) and for some other cases this process might not be wanted.

## What? :wrench:
- Add a row count validation flag on Abstract Writer
- Add a check on the Sink to enable row count validation

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release
