### PR TITLE
fix: add missing parameter, add setup libs

### DIFF
--- a/butterfree/load/writers/historical_feature_store_writer.py
+++ b/butterfree/load/writers/historical_feature_store_writer.py
@@ -113,9 +113,14 @@ class HistoricalFeatureStoreWriter(Writer):
         debug_mode: bool = False,
         interval_mode: bool = False,
         check_schema_hook: Hook = None,
+        row_count_validation: bool = True,
     ):
         super(HistoricalFeatureStoreWriter, self).__init__(
-            db_config or MetastoreConfig(), debug_mode, interval_mode
+            db_config or MetastoreConfig(),
+            debug_mode,
+            interval_mode,
+            False,
+            row_count_validation,
         )
         self.database = database or environment.get_variable(
             "FEATURE_STORE_HISTORICAL_DATABASE"

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,3 +7,5 @@ sphinxemoji==0.1.8
 sphinx-rtd-theme==0.5.2
 recommonmark==0.7.1
 pyarrow>=1.0.0
+setuptools
+wheel


### PR DESCRIPTION
## Why? :open_book:
- Add missing param on HistoricalFeatureStoreWriter
- Add libs in order to work `make package`