### PR TITLE
feat(MLOP-1985): optional params

### DIFF
--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -58,10 +58,7 @@ class Source(HookableComponent):
     """
 
     def __init__(
-        self,
-        readers: List[Reader] = None,
-        query: str = "",
-        eager_evaluation: bool = True,
+        self, readers: List[Reader], query: str = "", eager_evaluation: bool = True,
     ) -> None:
         super().__init__()
         self.enable_pre_hooks = False

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -58,7 +58,7 @@ class Source(HookableComponent):
     """
 
     def __init__(
-        self, readers: List[Reader], query: str = "", eager_evaluation: bool = True,
+        self, readers: List[Reader], query: str, eager_evaluation: bool = True,
     ) -> None:
         super().__init__()
         self.enable_pre_hooks = False

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -49,7 +49,7 @@ class Source(HookableComponent):
         temporary views regarding each reader and, after, will run the
         desired query and return a dataframe.
 
-        The `eager_evaluation` param forces Spark to apply the currently 
+        The `eager_evaluation` param forces Spark to apply the currently
         mapped changes to the DataFrame. When this parameter is set to
         False, Spark follows its standard behaviour of lazy evaluation.
         Lazy evaluation can improve Spark's performance as it allows

--- a/butterfree/extract/source.py
+++ b/butterfree/extract/source.py
@@ -49,13 +49,25 @@ class Source(HookableComponent):
         temporary views regarding each reader and, after, will run the
         desired query and return a dataframe.
 
+        The `eager_evaluation` param forces Spark to apply the currently 
+        mapped changes to the DataFrame. When this parameter is set to
+        False, Spark follows its standard behaviour of lazy evaluation.
+        Lazy evaluation can improve Spark's performance as it allows
+        Spark to build the best version of the execution plan.
+
     """
 
-    def __init__(self, readers: List[Reader], query: str) -> None:
+    def __init__(
+        self,
+        readers: List[Reader] = None,
+        query: str = "",
+        eager_evaluation: bool = True,
+    ) -> None:
         super().__init__()
         self.enable_pre_hooks = False
         self.readers = readers
         self.query = query
+        self.eager_evaluation = eager_evaluation
 
     def construct(
         self, client: SparkClient, start_date: str = None, end_date: str = None
@@ -87,7 +99,7 @@ class Source(HookableComponent):
 
         dataframe = client.sql(self.query)
 
-        if not dataframe.isStreaming:
+        if not dataframe.isStreaming and self.eager_evaluation:
             dataframe.cache().count()
 
         post_hook_df = self.run_post_hooks(dataframe)

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -98,7 +98,7 @@ class FeatureSet(HookableComponent):
     our dataframe (regarding the number of rows). A detailed explation of this
     method can be found at filter_duplicated_rows docstring.
 
-    The `eager_evaluation` param forces Spark to apply the currently 
+    The `eager_evaluation` param forces Spark to apply the currently
     mapped changes to the DataFrame. When this parameter is set to
     False, Spark follows its standard behaviour of lazy evaluation.
     Lazy evaluation can improve Spark's performance as it allows

--- a/butterfree/transform/feature_set.py
+++ b/butterfree/transform/feature_set.py
@@ -97,6 +97,12 @@ class FeatureSet(HookableComponent):
     values over key columns and timestamp column, we do this in order to reduce
     our dataframe (regarding the number of rows). A detailed explation of this
     method can be found at filter_duplicated_rows docstring.
+
+    The `eager_evaluation` param forces Spark to apply the currently 
+    mapped changes to the DataFrame. When this parameter is set to
+    False, Spark follows its standard behaviour of lazy evaluation.
+    Lazy evaluation can improve Spark's performance as it allows
+    Spark to build the best version of the execution plan.
     """
 
     def __init__(
@@ -107,6 +113,8 @@ class FeatureSet(HookableComponent):
         keys: List[KeyFeature],
         timestamp: TimestampFeature,
         features: List[Feature],
+        deduplicate_rows: bool = True,
+        eager_evaluation: bool = True,
     ) -> None:
         super().__init__()
         self.name = name
@@ -116,6 +124,8 @@ class FeatureSet(HookableComponent):
         self.timestamp = timestamp
         self.features = features
         self.incremental_strategy = IncrementalStrategy(column=TIMESTAMP_COLUMN)
+        self.deduplicate_rows = deduplicate_rows
+        self.eager_evaluation = eager_evaluation
 
     @property
     def name(self) -> str:
@@ -426,8 +436,10 @@ class FeatureSet(HookableComponent):
         ).select(*self.columns)
 
         if not output_df.isStreaming:
-            output_df = self._filter_duplicated_rows(output_df)
-            output_df.cache().count()
+            if self.deduplicate_rows:
+                output_df = self._filter_duplicated_rows(output_df)
+            if self.eager_evaluation:
+                output_df.cache().count()
 
         output_df = self.incremental_strategy.filter_with_incremental_strategy(
             dataframe=output_df, start_date=start_date, end_date=end_date


### PR DESCRIPTION
## Why? :open_book:
The `eager_evaluation` param forces Spark to apply the currently mapped changes to a DataFrame. When this parameter is set to False, Spark follows its standard behavior of lazy evaluation. Lazy evaluation can improve Spark's performance as it allows Spark to build the best version of the execution plan.
The `row_deduplication` is not applicable to all scenarios. For instance, when using Delta operations, row deduplication can be done through `merge` operations.

## What? :wrench:
- Add new arguments to enable/disable eager evaluation and row deduplication in Source and FeatureSet classes.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release

## How everything was tested? :straight_ruler:
- Databricks notebooks
