### PR TITLE
fix: cassandra configs

### DIFF
--- a/butterfree/configs/db/cassandra_config.py
+++ b/butterfree/configs/db/cassandra_config.py
@@ -247,7 +247,9 @@ class CassandraConfig(AbstractWriteConfig):
             cassandra_schema.append(
                 {
                     "column_name": features["column_name"],
-                    "type": cassandra_mapping[str(features["type"]).replace("()", "").lower()],
+                    "type": cassandra_mapping[
+                        str(features["type"]).replace("()", "").lower()
+                    ],
                     "primary_key": features["primary_key"],
                 }
             )

--- a/butterfree/configs/db/cassandra_config.py
+++ b/butterfree/configs/db/cassandra_config.py
@@ -228,26 +228,26 @@ class CassandraConfig(AbstractWriteConfig):
 
         """
         cassandra_mapping = {
-            "TimestampType": "timestamp",
-            "BinaryType": "boolean",
-            "BooleanType": "boolean",
-            "DateType": "timestamp",
-            "DecimalType": "decimal",
-            "DoubleType": "double",
-            "FloatType": "float",
-            "IntegerType": "int",
-            "LongType": "bigint",
-            "StringType": "text",
-            "ArrayType(LongType,true)": "frozen<list<bigint>>",
-            "ArrayType(StringType,true)": "frozen<list<text>>",
-            "ArrayType(FloatType,true)": "frozen<list<float>>",
+            "timestamptype": "timestamp",
+            "binarytype": "boolean",
+            "booleantype": "boolean",
+            "datetype": "timestamp",
+            "decimaltype": "decimal",
+            "doubletype": "double",
+            "floattype": "float",
+            "integertype": "int",
+            "longtype": "bigint",
+            "stringtype": "text",
+            "arraytype(longtype,true)": "frozen<list<bigint>>",
+            "arraytype(stringtype,true)": "frozen<list<text>>",
+            "arraytype(floattype,true)": "frozen<list<float>>",
         }
         cassandra_schema = []
         for features in schema:
             cassandra_schema.append(
                 {
                     "column_name": features["column_name"],
-                    "type": cassandra_mapping[str(features["type"]).replace("()", "")],
+                    "type": cassandra_mapping[str(features["type"]).replace("()", "").lower()],
                     "primary_key": features["primary_key"],
                 }
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyspark==3.5.1
 typer==0.4.2
 typing-extensions>3.7.4,<5
 boto3==1.17.*
+numpy==1.26.4


### PR DESCRIPTION
## Why? :open_book:
Adapt Cassandra Config to the new libs versions that generates values with lower case. Pin numpy as version 2.x was released.

## What? :open_book:
* Cassandra types as lowercase
* Pin numpy version