### PR TITLE
fix: Cassandra config keys

### DIFF
--- a/butterfree/configs/db/cassandra_config.py
+++ b/butterfree/configs/db/cassandra_config.py
@@ -238,9 +238,9 @@ class CassandraConfig(AbstractWriteConfig):
             "integertype": "int",
             "longtype": "bigint",
             "stringtype": "text",
-            "arraytype(longtype,true)": "frozen<list<bigint>>",
-            "arraytype(stringtype,true)": "frozen<list<text>>",
-            "arraytype(floattype,true)": "frozen<list<float>>",
+            "arraytype(longtype, true)": "frozen<list<bigint>>",
+            "arraytype(stringtype, true)": "frozen<list<text>>",
+            "arraytype(floattype, true)": "frozen<list<float>>",
         }
         cassandra_schema = []
         for features in schema:

--- a/tests/unit/butterfree/migrations/database_migration/conftest.py
+++ b/tests/unit/butterfree/migrations/database_migration/conftest.py
@@ -1,4 +1,11 @@
-from pyspark.sql.types import DoubleType, FloatType, LongType, TimestampType, ArrayType, StringType
+from pyspark.sql.types import (
+    ArrayType,
+    DoubleType,
+    FloatType,
+    LongType,
+    StringType,
+    TimestampType,
+)
 from pytest import fixture
 
 from butterfree.constants import DataType
@@ -30,7 +37,11 @@ def fs_schema():
         {"column_name": "id", "type": LongType(), "primary_key": True},
         {"column_name": "timestamp", "type": TimestampType(), "primary_key": True},
         {"column_name": "new_feature", "type": FloatType(), "primary_key": False},
-        {"column_name": "array_feature", "type": ArrayType(StringType(),True), "primary_key": False},
+        {
+            "column_name": "array_feature",
+            "type": ArrayType(StringType(), True),
+            "primary_key": False,
+        },
         {
             "column_name": "feature1__avg_over_1_week_rolling_windows",
             "type": FloatType(),

--- a/tests/unit/butterfree/migrations/database_migration/conftest.py
+++ b/tests/unit/butterfree/migrations/database_migration/conftest.py
@@ -1,4 +1,4 @@
-from pyspark.sql.types import DoubleType, FloatType, LongType, TimestampType
+from pyspark.sql.types import DoubleType, FloatType, LongType, TimestampType, ArrayType, StringType
 from pytest import fixture
 
 from butterfree.constants import DataType
@@ -30,6 +30,7 @@ def fs_schema():
         {"column_name": "id", "type": LongType(), "primary_key": True},
         {"column_name": "timestamp", "type": TimestampType(), "primary_key": True},
         {"column_name": "new_feature", "type": FloatType(), "primary_key": False},
+        {"column_name": "array_feature", "type": ArrayType(StringType(),True), "primary_key": False},
         {
             "column_name": "feature1__avg_over_1_week_rolling_windows",
             "type": FloatType(),

--- a/tests/unit/butterfree/migrations/database_migration/test_cassandra_migration.py
+++ b/tests/unit/butterfree/migrations/database_migration/test_cassandra_migration.py
@@ -33,9 +33,11 @@ class TestCassandraMigration:
         expected_query = [
             "CREATE TABLE test.table_name "
             "(id LongType, timestamp TimestampType, new_feature FloatType, "
+            "array_feature ArrayType(StringType(), True), "
             "feature1__avg_over_1_week_rolling_windows FloatType, "
             "PRIMARY KEY (id, timestamp));"
         ]
+
         query = cassandra_migration.create_query(fs_schema, "table_name")
 
         assert query, expected_query


### PR DESCRIPTION
## Why? :open_book:
Cassandra migration broke every time because there's a missing whitespace in the keys.

![Uploading image.png…]()


## What? :wrench:
Add whitespace; add tests