### PR TITLE
fix: performance adjustments, migrate

### DIFF
--- a/butterfree/migrations/database_migration/cassandra_migration.py
+++ b/butterfree/migrations/database_migration/cassandra_migration.py
@@ -78,17 +78,6 @@ class CassandraMigration(DatabaseMigration):
     def _get_alter_column_type_query(self, column: Diff, table_name: str) -> str:
         """Creates CQL statement to alter columns' types.
 
-        Args:
-            columns: list of Diff objects with ALTER_TYPE kind.
-            table_name: table name.
-
-        Returns:
-            Alter column type query.
-
-        """
-
-    def _get_alter_column_type_query(self, column: Diff, table_name: str) -> str:
-        """Creates CQL statement to alter columns' types.
             In Cassandra 3.4.x to 3.11.x alter type is not allowed.
             This method creates a temp column to comply.
 
@@ -100,7 +89,6 @@ class CassandraMigration(DatabaseMigration):
             Alter column type query.
 
         """
-
         temp_column_name = f"{column.column}_temp"
 
         add_temp_column_query = (
@@ -115,7 +103,8 @@ class CassandraMigration(DatabaseMigration):
             f"ALTER TABLE {table_name} RENAME {temp_column_name} TO {column.column};"
         )
 
-        return f"{add_temp_column_query} {copy_data_to_temp_query} {drop_old_column_query} {rename_temp_column_query};"
+        return (f"{add_temp_column_query} {copy_data_to_temp_query} "
+                f"{drop_old_column_query} {rename_temp_column_query};")
 
     @staticmethod
     def _get_create_table_query(columns: List[Dict[str, Any]], table_name: str) -> str:

--- a/butterfree/migrations/database_migration/cassandra_migration.py
+++ b/butterfree/migrations/database_migration/cassandra_migration.py
@@ -86,6 +86,7 @@ class CassandraMigration(DatabaseMigration):
             Alter column type query.
 
         """
+
     def _get_alter_column_type_query(self, column: Diff, table_name: str) -> str:
         """Creates CQL statement to alter columns' types.
             In Cassandra 3.4.x to 3.11.x alter type is not allowed.
@@ -102,14 +103,19 @@ class CassandraMigration(DatabaseMigration):
 
         temp_column_name = f"{column.column}_temp"
 
-        add_temp_column_query = f"ALTER TABLE {table_name} ADD {temp_column_name} {column.value};"
-        copy_data_to_temp_query = f"UPDATE {table_name} SET {temp_column_name} = {column.column};"
+        add_temp_column_query = (
+            f"ALTER TABLE {table_name} ADD {temp_column_name} {column.value};"
+        )
+        copy_data_to_temp_query = (
+            f"UPDATE {table_name} SET {temp_column_name} = {column.column};"
+        )
 
         drop_old_column_query = f"ALTER TABLE {table_name} DROP {column.column};"
-        rename_temp_column_query = f"ALTER TABLE {table_name} RENAME {temp_column_name} TO {column.column};"
+        rename_temp_column_query = (
+            f"ALTER TABLE {table_name} RENAME {temp_column_name} TO {column.column};"
+        )
 
         return f"{add_temp_column_query} {copy_data_to_temp_query} {drop_old_column_query} {rename_temp_column_query};"
-
 
     @staticmethod
     def _get_create_table_query(columns: List[Dict[str, Any]], table_name: str) -> str:

--- a/butterfree/migrations/database_migration/cassandra_migration.py
+++ b/butterfree/migrations/database_migration/cassandra_migration.py
@@ -103,8 +103,10 @@ class CassandraMigration(DatabaseMigration):
             f"ALTER TABLE {table_name} RENAME {temp_column_name} TO {column.column};"
         )
 
-        return (f"{add_temp_column_query} {copy_data_to_temp_query} "
-                f"{drop_old_column_query} {rename_temp_column_query};")
+        return (
+            f"{add_temp_column_query} {copy_data_to_temp_query} "
+            f"{drop_old_column_query} {rename_temp_column_query};"
+        )
 
     @staticmethod
     def _get_create_table_query(columns: List[Dict[str, Any]], table_name: str) -> str:

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -576,14 +576,17 @@ class AggregatedFeatureSet(FeatureSet):
 
         pre_hook_df = self.run_pre_hooks(dataframe)
 
-        output_df = reduce(
-            lambda df, feature: feature.transform(df),
-            self.keys + [self.timestamp],
-            pre_hook_df,
+        # Apply transformations
+        for feature in self.keys + [self.timestamp]:
+            output_df = feature.transform(pre_hook_df)
+
+        # Early filter data
+        output_df = self.incremental_strategy.filter_with_incremental_strategy(
+            dataframe=output_df, start_date=start_date, end_date=end_date
         )
 
         if self._windows and end_date is not None:
-            # run aggregations for each window
+            # Run aggregations for each window
             agg_list = [
                 self._aggregate(
                     dataframe=output_df,
@@ -603,13 +606,12 @@ class AggregatedFeatureSet(FeatureSet):
 
             # keeping this logic to maintain the same behavior for already implemented
             # feature sets
-
             if self._windows[0].slide == "1 day":
                 base_df = self._get_base_dataframe(
                     client=client, dataframe=output_df, end_date=end_date
                 )
 
-                # left join each aggregation result to our base dataframe
+                # Left join each aggregation result to our base dataframe
                 output_df = reduce(
                     lambda left, right: self._dataframe_join(
                         left,
@@ -635,19 +637,21 @@ class AggregatedFeatureSet(FeatureSet):
         else:
             output_df = self._aggregate(output_df, features=self.features)
 
-        output_df = self.incremental_strategy.filter_with_incremental_strategy(
-            dataframe=output_df, start_date=start_date, end_date=end_date
-        )
-
         output_df = output_df.select(*self.columns).replace(  # type: ignore
             float("nan"), None
         )
+
         if not output_df.isStreaming and self.deduplicate_rows:
             output_df = self._filter_duplicated_rows(output_df)
 
         post_hook_df = self.run_post_hooks(output_df)
 
+        # Eager evaluation, only if needed and managable
         if not output_df.isStreaming and self.eager_evaluation:
-            post_hook_df.cache().count()
+            # Small dataframes only
+            if output_df.count() < 1_000_000:
+                post_hook_df.cache().count()
+            else:
+                post_hook_df.cache()  # Cache without materialization for large volumes
 
         return post_hook_df

--- a/butterfree/transform/aggregated_feature_set.py
+++ b/butterfree/transform/aggregated_feature_set.py
@@ -576,11 +576,10 @@ class AggregatedFeatureSet(FeatureSet):
 
         pre_hook_df = self.run_pre_hooks(dataframe)
 
-        # Apply transformations
+        output_df = pre_hook_df
         for feature in self.keys + [self.timestamp]:
-            output_df = feature.transform(pre_hook_df)
+            output_df = feature.transform(output_df)
 
-        # Early filter data
         output_df = self.incremental_strategy.filter_with_incremental_strategy(
             dataframe=output_df, start_date=start_date, end_date=end_date
         )


### PR DESCRIPTION
## Why? :open_book:
We want the Transform phase to be as fast as possible.
Some Cassandra versions do not allow column type change.

## What? :wrench:
- Remove reduce in column transformations
- Apply incremental filter as soon as possible
- Force dataframe materialization only for small amount of data

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Release

## How everything was tested? :straight_ruler:
Databricks notebook

