### PR TITLE
feat(mlop-2456): add protection to host setting on cassandra_client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ style-check:
 	@echo "Code Style"
 	@echo "=========="
 	@echo ""
-	@python -m black --check -t py39 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" . && echo "\n\nSuccess" || (echo "\n\nFailure\n\nYou need to run \"make apply-style\" to apply style formatting to your code"; exit 1)
+	@python -m black --check -t py39 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|venv/" . && echo "\n\nSuccess" || (echo "\n\nFailure\n\nYou need to run \"make apply-style\" to apply style formatting to your code"; exit 1)
 
 .PHONY: quality-check
 ## run code quality checks with flake8
@@ -85,7 +85,7 @@ quality-check:
 	@echo "Flake 8"
 	@echo "======="
 	@echo ""
-	@python -m flake8 && echo "Success"
+	@python -m flake8 --exclude="venv"  && echo "Success"
 	@echo ""
 
 .PHONY: type-check
@@ -95,7 +95,7 @@ type-check:
 	@echo "mypy"
 	@echo "===="
 	@echo ""
-	@python -m mypy butterfree
+	@python -m mypy --exclude="venv" butterfree
 
 .PHONY: checks
 ## run all code checks
@@ -104,7 +104,7 @@ checks: style-check quality-check type-check
 .PHONY: apply-style
 ## fix stylistic errors with black
 apply-style:
-	@python -m black -t py39 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/" .
+	@python -m black -t py39 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|venv/" .
 	@python -m isort --atomic butterfree/ tests/
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ quality-check:
 	@echo "Flake 8"
 	@echo "======="
 	@echo ""
-	@python -m flake8 --exclude="venv"  && echo "Success"
+	@python -m flake8 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|venv/"  && echo "Success"
 	@echo ""
 
 .PHONY: type-check
@@ -95,7 +95,7 @@ type-check:
 	@echo "mypy"
 	@echo "===="
 	@echo ""
-	@python -m mypy --exclude="venv" butterfree
+	@python -m mypy --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|venv/" butterfree
 
 .PHONY: checks
 ## run all code checks

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ quality-check:
 	@echo "Flake 8"
 	@echo "======="
 	@echo ""
-	@python -m flake8 --exclude="build/|buck-out/|dist/|_build/|pip/|\.pip/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/|venv/"  && echo "Success"
+	python -m flake8 --exclude="dist,build,pip,.pip,deps,.venv,venv,.git,.hg,.mypy_cache,.tox" && echo "Success"
 	@echo ""
 
 .PHONY: type-check

--- a/butterfree/clients/cassandra_client.py
+++ b/butterfree/clients/cassandra_client.py
@@ -84,7 +84,7 @@ class CassandraClient(AbstractClient):
             list: A list of formatted Cassandra host strings.
 
         Raises:
-            ValueError: If the input is an empty string or if it is not a string
+            ValueError: If the input is an empty list/string or if it is not a string
                         (or a representation of a list) or a list of strings.
         """  # noqa: E501
         if isinstance(host, str):

--- a/tests/unit/butterfree/clients/test_cassandra_client.py
+++ b/tests/unit/butterfree/clients/test_cassandra_client.py
@@ -95,15 +95,15 @@ class TestCassandraClient:
 
     def test_initialize_with_string_host(self):
         client = CassandraClient(
-            host="192.168.1.1, 192.168.1.2", keyspace="dummy_keyspace"
+            host="127.0.0.0, 127.0.0.1", keyspace="dummy_keyspace"
         )
-        assert client.host == ["192.168.1.1", "192.168.1.2"]
+        assert client.host == ["127.0.0.0", "127.0.0.1"]
 
     def test_initialize_with_list_host(self):
         client = CassandraClient(
-            host=["192.168.1.1", "192.168.1.2"], keyspace="test_keyspace"
+            host=["127.0.0.0", "127.0.0.1"], keyspace="test_keyspace"
         )
-        assert client.host == ["192.168.1.1", "192.168.1.2"]
+        assert client.host == ["127.0.0.0", "127.0.0.1"]
 
     def test_initialize_with_empty_string_host(self):
         with pytest.raises(
@@ -131,10 +131,10 @@ class TestCassandraClient:
             ValueError,
             match=GENERIC_INVALID_HOST_ERROR,
         ):
-            CassandraClient(host=["192.168.1.1", 123], keyspace="test_keyspace")
+            CassandraClient(host=["127.0.0.0", 123], keyspace="test_keyspace")
 
     def test_initialize_with_list_of_string_hosts(self):
         client = CassandraClient(
-            host=["192.168.1.1, 192.168.1.2"], keyspace="test_keyspace"
+            host=["127.0.0.0, 127.0.0.1"], keyspace="test_keyspace"
         )
-        assert client.host == ["192.168.1.1", "192.168.1.2"]
+        assert client.host == ["127.0.0.0", "127.0.0.1"]

--- a/tests/unit/butterfree/clients/test_cassandra_client.py
+++ b/tests/unit/butterfree/clients/test_cassandra_client.py
@@ -94,9 +94,7 @@ class TestCassandraClient:
         assert sanitize_string(query) == sanitize_string(expected_query)
 
     def test_initialize_with_string_host(self):
-        client = CassandraClient(
-            host="127.0.0.0, 127.0.0.1", keyspace="dummy_keyspace"
-        )
+        client = CassandraClient(host="127.0.0.0, 127.0.0.1", keyspace="dummy_keyspace")
         assert client.host == ["127.0.0.0", "127.0.0.1"]
 
     def test_initialize_with_list_host(self):

--- a/tests/unit/butterfree/transform/transformations/conftest.py
+++ b/tests/unit/butterfree/transform/transformations/conftest.py
@@ -62,7 +62,7 @@ def target_df_spark(spark_context, spark_session):
             "timestamp": "2016-04-11 11:31:11",
             "feature1": 200,
             "feature2": 200,
-            "feature__cos": 0.4871876750070059,
+            "feature__cos": 0.48718767500700594,
         },
         {
             "id": 1,

--- a/tests/unit/butterfree/transform/transformations/conftest.py
+++ b/tests/unit/butterfree/transform/transformations/conftest.py
@@ -62,7 +62,7 @@ def target_df_spark(spark_context, spark_session):
             "timestamp": "2016-04-11 11:31:11",
             "feature1": 200,
             "feature2": 200,
-            "feature__cos": 0.48718767500700594,
+            "feature__cos": 0.4871876750070059,
         },
         {
             "id": 1,


### PR DESCRIPTION
# What 🔧 

- Makefile: changes to exclude `venv` files from checks and formatting
- Add `_validate_and_format_cassandra_host` and unit tests 
- `tests/unit/butterfree/transform/transformations/conftest.py`: fixing a test