### PR TITLE
fix: include extra-files config for version bump

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,11 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": true,
       "prerelease": true,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        "setup.py",
+        "butterfree/__init__.py"
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Why

release-please auto `__version__` bump relies on the explicit setting of the `extra-files` config.
